### PR TITLE
[chore] Fix filename comments to use .h

### DIFF
--- a/components/hub75/src/color/color_convert.h
+++ b/components/hub75/src/color/color_convert.h
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Stuart Parmenter
 // SPDX-License-Identifier: MIT
 //
-// @file color_convert.hpp
+// @file color_convert.h
 // @brief RGB565 scaling utilities for color conversion
 //
 // Provides functions to scale RGB565 color components (5-bit and 6-bit)

--- a/components/hub75/src/color/color_lut.h
+++ b/components/hub75/src/color/color_lut.h
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Stuart Parmenter
 // SPDX-License-Identifier: MIT
 //
-// @file color_lut.hpp
+// @file color_lut.h
 // @brief Color lookup tables for gamma correction
 
 #pragma once

--- a/components/hub75/src/drivers/driver_init.h
+++ b/components/hub75/src/drivers/driver_init.h
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Stuart Parmenter
 // SPDX-License-Identifier: MIT
 //
-// @file driver_init.hpp
+// @file driver_init.h
 // @brief Shift driver chip initialization
 
 #pragma once

--- a/components/hub75/src/panels/panel_layout.h
+++ b/components/hub75/src/panels/panel_layout.h
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Stuart Parmenter
 // SPDX-License-Identifier: MIT
 
-// @file panel_layout.hpp
+// @file panel_layout.h
 // @brief Multi-panel layout coordinate remapping
 
 // Based on https://github.com/mrcodetastic/ESP32-HUB75-MatrixPanel-DMA

--- a/components/hub75/src/panels/scan_patterns.h
+++ b/components/hub75/src/panels/scan_patterns.h
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Stuart Parmenter
 // SPDX-License-Identifier: MIT
 
-// @file scan_patterns.hpp
+// @file scan_patterns.h
 // @brief Scan pattern coordinate remapping
 
 // Based on https://github.com/mrcodetastic/ESP32-HUB75-MatrixPanel-DMA

--- a/components/hub75/src/platforms/gdma/gdma_dma.h
+++ b/components/hub75/src/platforms/gdma/gdma_dma.h
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Stuart Parmenter
 // SPDX-License-Identifier: MIT
 //
-// @file gdma_dma.hpp
+// @file gdma_dma.h
 // @brief ESP32-S3 LCD_CAM peripheral + GDMA for HUB75
 //
 // Uses ESP32-S3's LCD_CAM peripheral with direct register access

--- a/components/hub75/src/platforms/i2s/i2s_dma.h
+++ b/components/hub75/src/platforms/i2s/i2s_dma.h
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Stuart Parmenter
 // SPDX-License-Identifier: MIT
 //
-// @file i2s_dma.hpp
+// @file i2s_dma.h
 // @brief ESP32/ESP32-S2 I2S DMA engine (LCD mode)
 //
 // Self-contained I2S+DMA implementation with BCM, pixel operations,

--- a/components/hub75/src/platforms/parlio/parlio_dma.h
+++ b/components/hub75/src/platforms/parlio/parlio_dma.h
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Stuart Parmenter
 // SPDX-License-Identifier: MIT
 //
-// @file parlio_dma.hpp
+// @file parlio_dma.h
 // @brief PARLIO peripheral implementation for HUB75 (ESP32-P4/C6)
 //
 // Uses PARLIO TX peripheral with optional clock gating (P4 only) to

--- a/components/hub75/src/platforms/platform_detect.h
+++ b/components/hub75/src/platforms/platform_detect.h
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Stuart Parmenter
 // SPDX-License-Identifier: MIT
 //
-// @file platform_detect.hpp
+// @file platform_detect.h
 // @brief Platform detection and DMA engine selection
 
 #pragma once

--- a/components/hub75/src/platforms/platform_dma.h
+++ b/components/hub75/src/platforms/platform_dma.h
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Stuart Parmenter
 // SPDX-License-Identifier: MIT
 //
-// @file platform_dma.hpp
+// @file platform_dma.h
 // @brief Platform-agnostic DMA interface
 //
 // This header provides a common interface that all platform-specific


### PR DESCRIPTION
I had headers as .hpp for a minute, cleaning up old references.