### PR TITLE
Enable esp32c6 builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        idf_target: [esp32, esp32s2, esp32s3, esp32p4]
+        idf_target: [esp32, esp32s2, esp32s3, esp32c6, esp32p4]
         idf_ver: [v4.4.8, v5.5.1, v6.0-dev]
         # v4.4.8: Latest 4.4 bugfix release (legacy support)
         # v5.5.1: Current stable release
         # v6.0-dev: Development branch (may have breaking changes)
         exclude:
-          # ESP32-P4 only supported on ESP-IDF 5.x+
+          # ESP32-C6 and ESP32-P4 only supported on ESP-IDF 5.x+
+          - idf_target: esp32c6
+            idf_ver: v4.4.8
           - idf_target: esp32p4
             idf_ver: v4.4.8
 

--- a/components/hub75/idf_component.yml
+++ b/components/hub75/idf_component.yml
@@ -16,8 +16,8 @@ targets:
   - esp32
   - esp32s2
   - esp32s3
+  - esp32c6
   - esp32p4
-  # - esp32c6  # Should work, but untested
 
 dependencies:
   idf:


### PR DESCRIPTION
C6 supports parlio and is already ifdef'd.  Support is currently untested on hardware, but should work