### PR TITLE
Bump esp-idf version from 5.5.1 to 5.5.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
       fail-fast: false
       matrix:
         idf_target: [esp32, esp32s2, esp32s3, esp32p4]
-        idf_ver: [v4.4.8, v5.5.1, v6.0-dev]
+        idf_ver: [v4.4.8, v5.5.2, v6.0-dev]
         # v4.4.8: Latest 4.4 bugfix release (legacy support)
-        # v5.5.1: Current stable release
+        # v5.5.2: Current stable release
         # v6.0-dev: Development branch (may have breaking changes)
         exclude:
           # ESP32-P4 only supported on ESP-IDF 5.x+


### PR DESCRIPTION
Update CI target -- https://docs.espressif.com/projects/esp-idf/en/v5.5.2/esp32/