### PR TITLE
Optimize draw_pixels with consecutive pixel caching

### DIFF
--- a/components/hub75/src/platforms/gdma/gdma_dma.cpp
+++ b/components/hub75/src/platforms/gdma/gdma_dma.cpp
@@ -577,35 +577,52 @@ HUB75_IRAM void GdmaDma::draw_pixels(uint16_t x, uint16_t y, uint16_t w, uint16_
 
       HUB75_PROFILE_STAGE(PROFILE_TRANSFORM);
 
-      // Extract RGB888 from pixel format (always_inline will inline the switch)
-      uint8_t r8 = 0, g8 = 0, b8 = 0;
-      extract_rgb888_from_format(pixel_ptr, 0, format, color_order, big_endian, r8, g8, b8);
+      // Pack raw pixel bytes into uint32_t for fast comparison
+      uint32_t current_raw;
+      if (format == Hub75PixelFormat::RGB565) {
+        current_raw = *reinterpret_cast<const uint16_t *>(pixel_ptr);
+      } else if (format == Hub75PixelFormat::RGB888) {
+        current_raw = pixel_ptr[0] | (pixel_ptr[1] << 8) | (pixel_ptr[2] << 16);
+      } else {
+        current_raw = *reinterpret_cast<const uint32_t *>(pixel_ptr);
+      }
+
+      // Only recompute patterns if raw pixel changed (skips extraction, LUT, and pattern computation)
+      if (current_raw != cached_raw_pixel_) {
+        // Extract RGB888 from pixel format (always_inline will inline the switch)
+        uint8_t r8 = 0, g8 = 0, b8 = 0;
+        extract_rgb888_from_format(pixel_ptr, 0, format, color_order, big_endian, r8, g8, b8);
+
+        HUB75_PROFILE_STAGE(PROFILE_EXTRACT);
+
+        // Apply LUT correction
+        const uint16_t r_corrected = lut_[r8];
+        const uint16_t g_corrected = lut_[g8];
+        const uint16_t b_corrected = lut_[b8];
+
+        HUB75_PROFILE_STAGE(PROFILE_LUT);
+
+        // Pre-compute bit patterns for all bit planes using branchless bit extraction
+        for (int bit = 0; bit < bit_depth_; bit++) {
+          const uint16_t r_bit = (r_corrected >> bit) & 1;
+          const uint16_t g_bit = (g_corrected >> bit) & 1;
+          const uint16_t b_bit = (b_corrected >> bit) & 1;
+          cached_upper_patterns_[bit] = (r_bit << R1_BIT) | (g_bit << G1_BIT) | (b_bit << B1_BIT);
+          cached_lower_patterns_[bit] = (r_bit << R2_BIT) | (g_bit << G2_BIT) | (b_bit << B2_BIT);
+        }
+        cached_raw_pixel_ = current_raw;
+      }
       pixel_ptr += pixel_stride;
 
-      HUB75_PROFILE_STAGE(PROFILE_EXTRACT);
-
-      // Apply LUT correction
-      const uint16_t r_corrected = lut_[r8];
-      const uint16_t g_corrected = lut_[g8];
-      const uint16_t b_corrected = lut_[b8];
-
-      HUB75_PROFILE_STAGE(PROFILE_LUT);
-
-      // Branchless bit-plane update using shift+and (avoids ternary branches on Xtensa)
+      // Apply cached patterns to all bit planes
       uint8_t *base_ptr = target_buffers[row].data;
       for (int bit = 0; bit < bit_depth_; bit++) {
         uint16_t *buf = (uint16_t *) (base_ptr + (bit * bit_plane_stride));
-
-        // Extract single bits (0 or 1) without branches using shift+and
-        const uint16_t r_bit = (r_corrected >> bit) & 1;
-        const uint16_t g_bit = (g_corrected >> bit) & 1;
-        const uint16_t b_bit = (b_corrected >> bit) & 1;
-
         uint16_t word = buf[px];
         if (is_lower) {
-          word = (word & ~RGB_LOWER_MASK) | (r_bit << R2_BIT) | (g_bit << G2_BIT) | (b_bit << B2_BIT);
+          word = (word & ~RGB_LOWER_MASK) | cached_lower_patterns_[bit];
         } else {
-          word = (word & ~RGB_UPPER_MASK) | (r_bit << R1_BIT) | (g_bit << G1_BIT) | (b_bit << B1_BIT);
+          word = (word & ~RGB_UPPER_MASK) | cached_upper_patterns_[bit];
         }
         buf[px] = word;
       }

--- a/components/hub75/src/platforms/gdma/gdma_dma.h
+++ b/components/hub75/src/platforms/gdma/gdma_dma.h
@@ -165,6 +165,12 @@ class GdmaDma : public PlatformDma {
   // Brightness control (implementation of base class interface)
   uint8_t basis_brightness_;  // 1-255
   float intensity_;           // 0.0-1.0
+
+  // Pixel pattern cache for consecutive identical pixels optimization
+  // Persists across draw_pixels() calls to benefit single-pixel APIs
+  uint32_t cached_raw_pixel_ = 0;  // Raw source bytes packed into uint32_t
+  uint16_t cached_upper_patterns_[HUB75_BIT_DEPTH] = {0};
+  uint16_t cached_lower_patterns_[HUB75_BIT_DEPTH] = {0};
 };
 
 }  // namespace hub75

--- a/components/hub75/src/platforms/i2s/i2s_dma.cpp
+++ b/components/hub75/src/platforms/i2s/i2s_dma.cpp
@@ -1027,35 +1027,52 @@ HUB75_IRAM void I2sDma::draw_pixels(uint16_t x, uint16_t y, uint16_t w, uint16_t
 
       HUB75_PROFILE_STAGE(PROFILE_TRANSFORM);
 
-      // Extract RGB888 from pixel format (always_inline will inline the switch)
-      uint8_t r8 = 0, g8 = 0, b8 = 0;
-      extract_rgb888_from_format(pixel_ptr, 0, format, color_order, big_endian, r8, g8, b8);
+      // Pack raw pixel bytes into uint32_t for fast comparison
+      uint32_t current_raw;
+      if (format == Hub75PixelFormat::RGB565) {
+        current_raw = *reinterpret_cast<const uint16_t *>(pixel_ptr);
+      } else if (format == Hub75PixelFormat::RGB888) {
+        current_raw = pixel_ptr[0] | (pixel_ptr[1] << 8) | (pixel_ptr[2] << 16);
+      } else {
+        current_raw = *reinterpret_cast<const uint32_t *>(pixel_ptr);
+      }
+
+      // Only recompute patterns if raw pixel changed (skips extraction, LUT, and pattern computation)
+      if (current_raw != cached_raw_pixel_) {
+        // Extract RGB888 from pixel format (always_inline will inline the switch)
+        uint8_t r8 = 0, g8 = 0, b8 = 0;
+        extract_rgb888_from_format(pixel_ptr, 0, format, color_order, big_endian, r8, g8, b8);
+
+        HUB75_PROFILE_STAGE(PROFILE_EXTRACT);
+
+        // Apply LUT correction
+        const uint16_t r_corrected = lut_[r8];
+        const uint16_t g_corrected = lut_[g8];
+        const uint16_t b_corrected = lut_[b8];
+
+        HUB75_PROFILE_STAGE(PROFILE_LUT);
+
+        // Pre-compute bit patterns for all bit planes using branchless bit extraction
+        for (int bit = 0; bit < bit_depth_; bit++) {
+          const uint16_t r_bit = (r_corrected >> bit) & 1;
+          const uint16_t g_bit = (g_corrected >> bit) & 1;
+          const uint16_t b_bit = (b_corrected >> bit) & 1;
+          cached_upper_patterns_[bit] = (r_bit << R1_BIT) | (g_bit << G1_BIT) | (b_bit << B1_BIT);
+          cached_lower_patterns_[bit] = (r_bit << R2_BIT) | (g_bit << G2_BIT) | (b_bit << B2_BIT);
+        }
+        cached_raw_pixel_ = current_raw;
+      }
       pixel_ptr += pixel_stride;
 
-      HUB75_PROFILE_STAGE(PROFILE_EXTRACT);
-
-      // Apply LUT correction
-      const uint16_t r_corrected = lut_[r8];
-      const uint16_t g_corrected = lut_[g8];
-      const uint16_t b_corrected = lut_[b8];
-
-      HUB75_PROFILE_STAGE(PROFILE_LUT);
-
-      // Branchless bit-plane update using shift+and (avoids ternary branches on Xtensa)
+      // Apply cached patterns to all bit planes
       uint8_t *base_ptr = target_buffers[row].data;
       for (int bit = 0; bit < bit_depth_; bit++) {
         uint16_t *buf = (uint16_t *) (base_ptr + (bit * bit_plane_stride));
-
-        // Extract single bits (0 or 1) without branches using shift+and
-        const uint16_t r_bit = (r_corrected >> bit) & 1;
-        const uint16_t g_bit = (g_corrected >> bit) & 1;
-        const uint16_t b_bit = (b_corrected >> bit) & 1;
-
         uint16_t word = buf[px];
         if (is_lower) {
-          word = (word & ~RGB_LOWER_MASK) | (r_bit << R2_BIT) | (g_bit << G2_BIT) | (b_bit << B2_BIT);
+          word = (word & ~RGB_LOWER_MASK) | cached_lower_patterns_[bit];
         } else {
-          word = (word & ~RGB_UPPER_MASK) | (r_bit << R1_BIT) | (g_bit << G1_BIT) | (b_bit << B1_BIT);
+          word = (word & ~RGB_UPPER_MASK) | cached_upper_patterns_[bit];
         }
         buf[px] = word;
       }

--- a/components/hub75/src/platforms/i2s/i2s_dma.h
+++ b/components/hub75/src/platforms/i2s/i2s_dma.h
@@ -161,6 +161,12 @@ class I2sDma : public PlatformDma {
   // Brightness control (implementation of base class interface)
   uint8_t basis_brightness_;  // 1-255
   float intensity_;           // 0.0-1.0
+
+  // Pixel pattern cache for consecutive identical pixels optimization
+  // Persists across draw_pixels() calls to benefit single-pixel APIs
+  uint32_t cached_raw_pixel_ = 0;  // Raw source bytes packed into uint32_t
+  uint16_t cached_upper_patterns_[HUB75_BIT_DEPTH] = {0};
+  uint16_t cached_lower_patterns_[HUB75_BIT_DEPTH] = {0};
 };
 
 }  // namespace hub75

--- a/components/hub75/src/platforms/parlio/parlio_dma.cpp
+++ b/components/hub75/src/platforms/parlio/parlio_dma.cpp
@@ -939,34 +939,51 @@ HUB75_IRAM void ParlioDma::draw_pixels(uint16_t x, uint16_t y, uint16_t w, uint1
         is_lower = transformed.is_lower;
       }
 
-      // Extract RGB888 from pixel format (always_inline will inline the switch)
-      uint8_t r8 = 0, g8 = 0, b8 = 0;
-      extract_rgb888_from_format(pixel_ptr, 0, format, color_order, big_endian, r8, g8, b8);
-      pixel_ptr += pixel_stride;
+      // Pack raw pixel bytes into uint32_t for fast comparison
+      uint32_t current_raw;
+      if (format == Hub75PixelFormat::RGB565) {
+        current_raw = *reinterpret_cast<const uint16_t *>(pixel_ptr);
+      } else if (format == Hub75PixelFormat::RGB888) {
+        current_raw = pixel_ptr[0] | (pixel_ptr[1] << 8) | (pixel_ptr[2] << 16);
+      } else {
+        current_raw = *reinterpret_cast<const uint32_t *>(pixel_ptr);
+      }
 
-      // Apply LUT correction
-      const uint16_t r_corrected = lut_[r8];
-      const uint16_t g_corrected = lut_[g8];
-      const uint16_t b_corrected = lut_[b8];
+      // Only recompute patterns if raw pixel changed (skips extraction, LUT, and pattern computation)
+      if (current_raw != cached_raw_pixel_) {
+        // Extract RGB888 from pixel format (always_inline will inline the switch)
+        uint8_t r8 = 0, g8 = 0, b8 = 0;
+        extract_rgb888_from_format(pixel_ptr, 0, format, color_order, big_endian, r8, g8, b8);
+
+        // Apply LUT correction
+        const uint16_t r_corrected = lut_[r8];
+        const uint16_t g_corrected = lut_[g8];
+        const uint16_t b_corrected = lut_[b8];
+
+        // Pre-compute bit patterns for all bit planes using branchless bit extraction
+        for (int bit = 0; bit < bit_depth_; bit++) {
+          const uint16_t r_bit = (r_corrected >> bit) & 1;
+          const uint16_t g_bit = (g_corrected >> bit) & 1;
+          const uint16_t b_bit = (b_corrected >> bit) & 1;
+          cached_upper_patterns_[bit] = (r_bit << R1_BIT) | (g_bit << G1_BIT) | (b_bit << B1_BIT);
+          cached_lower_patterns_[bit] = (r_bit << R2_BIT) | (g_bit << G2_BIT) | (b_bit << B2_BIT);
+        }
+        cached_raw_pixel_ = current_raw;
+      }
+      pixel_ptr += pixel_stride;
 
       // Pre-compute base index for this row's bit planes
       const int row_base_idx = row * bit_depth_;
 
-      // Branchless bit-plane update using shift+and
+      // Apply cached patterns to all bit planes
       // PARLIO bit layout: [CLK_GATE(15)|ADDR(14-11)|--|LAT(9)|OE(8)|--|--|R2(4)|R1(5)|G2(2)|G1(3)|B2(0)|B1(1)]
       for (int bit = 0; bit < bit_depth_; bit++) {
         BitPlaneBuffer &bp = target_buffers[row_base_idx + bit];
-
-        // Extract single bits (0 or 1) without branches using shift+and
-        const uint16_t r_bit = (r_corrected >> bit) & 1;
-        const uint16_t g_bit = (g_corrected >> bit) & 1;
-        const uint16_t b_bit = (b_corrected >> bit) & 1;
-
         uint16_t word = bp.data[px];
         if (is_lower) {
-          word = (word & ~RGB_LOWER_MASK) | (r_bit << R2_BIT) | (g_bit << G2_BIT) | (b_bit << B2_BIT);
+          word = (word & ~RGB_LOWER_MASK) | cached_lower_patterns_[bit];
         } else {
-          word = (word & ~RGB_UPPER_MASK) | (r_bit << R1_BIT) | (g_bit << G1_BIT) | (b_bit << B1_BIT);
+          word = (word & ~RGB_UPPER_MASK) | cached_upper_patterns_[bit];
         }
         bp.data[px] = word;
       }

--- a/components/hub75/src/platforms/parlio/parlio_dma.h
+++ b/components/hub75/src/platforms/parlio/parlio_dma.h
@@ -111,6 +111,12 @@ class ParlioDma : public PlatformDma {
   uint8_t basis_brightness_;
   float intensity_;
   bool transfer_started_;
+
+  // Pixel pattern cache for consecutive identical pixels optimization
+  // Persists across draw_pixels() calls to benefit single-pixel APIs
+  uint32_t cached_raw_pixel_ = 0;  // Raw source bytes packed into uint32_t
+  uint16_t cached_upper_patterns_[HUB75_BIT_DEPTH] = {0};
+  uint16_t cached_lower_patterns_[HUB75_BIT_DEPTH] = {0};
 };
 
 }  // namespace hub75


### PR DESCRIPTION
When consecutive pixels have the same RGB values, skip redundant LUT
lookups and bit pattern computation by caching the pre-computed upper
and lower patterns. This avoids 3 LUT lookups and bit_depth×6 conditional
branches per duplicate pixel.

Particularly beneficial for images with solid color regions, UI elements
with flat backgrounds, and anti-aliased text with identical background pixels.