### PR TITLE
Have release drafter run uv lock after updating pyproject version

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -24,16 +24,21 @@ jobs:
         with:
           ssh-key: ${{ secrets.DEPLOY_KEY }}
 
+      - uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7
+
       - name: Update version files
         run: |
           sed -i "s/\"version\": .*/\"version\": \"${{ steps.drafter.outputs.resolved_version }}\",/g" library.json
           sed -i "s/^version = .*/version = \"${{ steps.drafter.outputs.resolved_version }}\"/" pyproject.toml
+
+      - name: Regenerate lockfile
+        run: uv lock
 
       - name: Commit changes
         run: |
           if ! git diff --quiet; then
             git config --global user.name "github-actions[bot]"
             git config --global user.email "github-actions[bot]@users.noreply.github.com"
-            git commit -am "Bump version to ${{ steps.drafter.outputs.resolved_version }}"
+            git commit -am "Bump version to ${{ steps.drafter.outputs.resolved_version }} [skip ci]"
             git push
           fi

--- a/uv.lock
+++ b/uv.lock
@@ -47,7 +47,7 @@ wheels = [
 
 [[package]]
 name = "esp-hub75"
-version = "0.1.7"
+version = "0.2.2"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Add uv setup and regenerate lockfile step to the release-drafter workflow.
Also update the commit message to include [skip ci] to prevent redundant CI runs.