### PR TITLE
Add frame callback support to DMA classes for frame completion handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,5 @@
-# ESP32 HUB75 DMA Driver - Root Project File
-# This file defines the ESP-IDF project structure
+# ESP32 HUB75 DMA Driver - ESP-IDF component wrapper
+# The actual component lives in components/hub75.
+# This wrapper allows the repo to be added under project components/.
 
-cmake_minimum_required(VERSION 3.16)
-
-# Include ESP-IDF build system
-include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-
-# Define the project
-project(hub75)
+include(${CMAKE_CURRENT_LIST_DIR}/components/hub75/CMakeLists.txt)

--- a/components/hub75/CMakeLists.txt
+++ b/components/hub75/CMakeLists.txt
@@ -123,3 +123,4 @@ foreach(opt IN LISTS DEPRECATED_GAMMA_OPTIONS)
             "Run 'idf.py save-defconfig' to generate updated config.")
     endif()
 endforeach()
+

--- a/components/hub75/CMakeLists.txt
+++ b/components/hub75/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 # Build REQUIRES list conditionally (esp_mm only exists in ESP-IDF 5.x for P4/C6)
 # Use IDF_TARGET (CMake variable) not CONFIG_IDF_TARGET_* (Kconfig, not yet available)
+set(HUB75_COMPONENT_DIR "${CMAKE_CURRENT_LIST_DIR}")
 set(HUB75_REQUIRES
     driver
     esp_timer
@@ -22,16 +23,16 @@ endif()
 
 idf_component_register(
     SRCS
-        "src/core/hub75_driver.cpp"
-        "src/color/color_lut.cpp"
-        "src/color/color_convert.cpp"
-        "src/platforms/platform_detect.cpp"
-        "src/platforms/platform_dma.cpp"
-        "src/drivers/fm6126a.cpp"
+        "${HUB75_COMPONENT_DIR}/src/core/hub75_driver.cpp"
+        "${HUB75_COMPONENT_DIR}/src/color/color_lut.cpp"
+        "${HUB75_COMPONENT_DIR}/src/color/color_convert.cpp"
+        "${HUB75_COMPONENT_DIR}/src/platforms/platform_detect.cpp"
+        "${HUB75_COMPONENT_DIR}/src/platforms/platform_dma.cpp"
+        "${HUB75_COMPONENT_DIR}/src/drivers/fm6126a.cpp"
         # Platform-specific sources added conditionally below
     INCLUDE_DIRS
-        "include"
-        "src"
+        "${HUB75_COMPONENT_DIR}/include"
+        "${HUB75_COMPONENT_DIR}/src"
     REQUIRES
         ${HUB75_REQUIRES}
 )
@@ -39,16 +40,16 @@ idf_component_register(
 # Platform-specific source files
 if(CONFIG_IDF_TARGET_ESP32 OR CONFIG_IDF_TARGET_ESP32S2)
     target_sources(${COMPONENT_LIB} PRIVATE
-        "src/platforms/i2s/i2s_dma.cpp"
+        "${HUB75_COMPONENT_DIR}/src/platforms/i2s/i2s_dma.cpp"
     )
 elseif(CONFIG_IDF_TARGET_ESP32S3)
     target_sources(${COMPONENT_LIB} PRIVATE
-        "src/platforms/gdma/gdma_dma.cpp"
+        "${HUB75_COMPONENT_DIR}/src/platforms/gdma/gdma_dma.cpp"
     )
 elseif(CONFIG_IDF_TARGET_ESP32P4 OR CONFIG_IDF_TARGET_ESP32C6)
     # PARLIO peripheral (ESP32-P4 has clock gating, ESP32-C6 does not)
     target_sources(${COMPONENT_LIB} PRIVATE
-        "src/platforms/parlio/parlio_dma.cpp"
+        "${HUB75_COMPONENT_DIR}/src/platforms/parlio/parlio_dma.cpp"
     )
 endif()
 

--- a/components/hub75/CMakeLists.txt
+++ b/components/hub75/CMakeLists.txt
@@ -13,6 +13,11 @@ set(HUB75_REQUIRES
 if(IDF_TARGET STREQUAL "esp32p4" OR IDF_TARGET STREQUAL "esp32c6")
     list(APPEND HUB75_REQUIRES esp_mm)
 endif()
+
+if(IDF_TARGET STREQUAL "esp32p4")
+    list(APPEND HUB75_REQUIRES esp_driver_ppa)
+endif()
+
 # ESP-IDF 6.0+ split drivers into separate components
 if(IDF_VERSION_MAJOR GREATER_EQUAL 6)
     list(APPEND HUB75_REQUIRES esp_driver_gpio)

--- a/components/hub75/CMakeLists.txt
+++ b/components/hub75/CMakeLists.txt
@@ -8,6 +8,7 @@ set(HUB75_REQUIRES
     driver
     esp_timer
     esp_hw_support
+    esp_driver_dma
     freertos
 )
 if(IDF_TARGET STREQUAL "esp32p4" OR IDF_TARGET STREQUAL "esp32c6")

--- a/components/hub75/CMakeLists.txt
+++ b/components/hub75/CMakeLists.txt
@@ -9,6 +9,8 @@ set(HUB75_REQUIRES
     esp_timer
     esp_hw_support
     freertos
+    esp_mm
+    esp_driver_dma
 )
 if(IDF_TARGET STREQUAL "esp32p4" OR IDF_TARGET STREQUAL "esp32c6")
     list(APPEND HUB75_REQUIRES esp_mm)

--- a/components/hub75/CMakeLists.txt
+++ b/components/hub75/CMakeLists.txt
@@ -8,7 +8,6 @@ set(HUB75_REQUIRES
     driver
     esp_timer
     esp_hw_support
-    esp_driver_dma
     freertos
 )
 if(IDF_TARGET STREQUAL "esp32p4" OR IDF_TARGET STREQUAL "esp32c6")

--- a/components/hub75/include/hub75.h
+++ b/components/hub75/include/hub75.h
@@ -57,6 +57,16 @@ class Hub75Driver {
    */
   void end();
 
+  /**
+   * @brief Register a callback to be called on each frame completion
+   *
+   * This callback is executed from an ISR.
+   *
+   * @param callback Function to call
+   * @param arg Argument to pass to the callback
+   */
+  void set_frame_callback(Hub75FrameCallback callback, void *arg);
+
   // ========================================================================
   // Pixel Drawing API
   // ========================================================================

--- a/components/hub75/include/hub75.h
+++ b/components/hub75/include/hub75.h
@@ -208,6 +208,12 @@ class Hub75Driver {
    */
   bool is_running() const;
 
+  /**
+   * @brief Get platform-specific DMA handle for advanced use cases
+   * @return Pointer to PlatformDma implementation
+   */
+  hub75::PlatformDma* getDmaEngine() const { return dma_; }
+
  private:
   Hub75Config config_;
   bool running_;

--- a/components/hub75/include/hub75.h
+++ b/components/hub75/include/hub75.h
@@ -53,6 +53,21 @@ class Hub75Driver {
   bool begin();
 
   /**
+   * @brief Set the minimum refresh rate before begin() allocates BCM timing.
+   * @return false if the driver is already running.
+   */
+  bool set_min_refresh_rate(uint16_t refresh_rate);
+
+  /**
+   * @brief Set the HUB75 shift clock before begin() initializes the transport.
+   * @return false if the driver is already running.
+   */
+  bool set_output_clock_speed(Hub75ClockSpeed clock_speed);
+
+  /** Configure the physical color data-pin order before begin(). */
+  bool set_pin_color_order(Hub75PinColorOrder order);
+
+  /**
    * @brief Stop refresh and release hardware resources
    */
   void end();
@@ -226,6 +241,7 @@ class Hub75Driver {
 
  private:
   Hub75Config config_;
+  Hub75Pins original_pins_;
   bool running_;
 
   // Platform-specific DMA engine

--- a/components/hub75/include/hub75_types.h
+++ b/components/hub75/include/hub75_types.h
@@ -9,6 +9,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+typedef bool (*Hub75FrameCallback)(void *arg);
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/components/hub75/include/hub75_types.h
+++ b/components/hub75/include/hub75_types.h
@@ -42,6 +42,7 @@ enum class Hub75ColorOrder {
  * visual artifacts or instability, try reducing the clock speed.
  */
 enum class Hub75ClockSpeed : uint32_t {
+  HZ_4M = 4000000,
   HZ_8M = 8000000,
   HZ_10M = 10000000,
   HZ_16M = 16000000,

--- a/components/hub75/include/hub75_types.h
+++ b/components/hub75/include/hub75_types.h
@@ -32,6 +32,16 @@ enum class Hub75ColorOrder {
   BGR,  // Blue-Green-Red (xBGR or BGRx)
 };
 
+/** Physical ordering of the HUB75 red, green, and blue data pins. */
+enum class Hub75PinColorOrder {
+  RGB,
+  RBG,
+  GRB,
+  GBR,
+  BRG,
+  BGR,
+};
+
 /**
  * @brief Output clock speed options
  *
@@ -79,6 +89,7 @@ enum class Hub75ShiftDriver {
   GENERIC,   // Standard shift register (no special init)
   FM6126A,   // FM6126A / ICN2038S (very common in modern panels!)
   ICN2038S,  // Alias for FM6126A
+  ICN2069,   // ICN2069 / FM6565S — embedded-PWM constant-current family, drop-in compatible with FM6126A init
   FM6124,    // FM6124 family
   MBI5124,   // MBI5124 (requires positive clock edge)
   DP3246     // DP3246 (special timing requirements)
@@ -201,6 +212,11 @@ struct Hub75Config {
 
   Hub75ClockSpeed output_clock_speed = Hub75ClockSpeed::HZ_20M;  // Output clock speed (default: 20MHz)
   uint16_t min_refresh_rate = 60;                                // Minimum refresh rate in Hz (default: 60)
+  // Row whose final BCM descriptor raises the once-per-refresh callback.
+  // -1 keeps the conventional callback at the end of the frame. A preceding
+  // row can be selected when a single live DMA buffer must be updated only
+  // after a latency-sensitive region has already been scanned.
+  int8_t frame_sync_row = -1;
 
   // ========================================
   // Timing

--- a/components/hub75/src/core/hub75_driver.cpp
+++ b/components/hub75/src/core/hub75_driver.cpp
@@ -204,6 +204,12 @@ void Hub75Driver::set_intensity(float intensity) {
   }
 }
 
+void Hub75Driver::set_frame_callback(Hub75FrameCallback callback, void *arg) {
+  if (dma_) {
+    dma_->set_frame_callback(callback, arg);
+  }
+}
+
 // ============================================================================
 // Information
 // ============================================================================

--- a/components/hub75/src/core/hub75_driver.cpp
+++ b/components/hub75/src/core/hub75_driver.cpp
@@ -44,7 +44,8 @@ using PlatformDMAImpl = ParlioDma;
 // Constructor / Destructor
 // ============================================================================
 
-Hub75Driver::Hub75Driver(const Hub75Config &config) : config_(config), running_(false), dma_(nullptr) {
+Hub75Driver::Hub75Driver(const Hub75Config &config)
+    : config_(config), original_pins_(config.pins), running_(false), dma_(nullptr) {
   ESP_LOGI(TAG, "Driver created for %s (%s)", getPlatformName(), getDMAEngineName());
   ESP_LOGI(TAG, "Panel: %dx%d, Layout: %dx%d, Virtual: %dx%d", (unsigned int) config_.panel_width,
            (unsigned int) config_.panel_height, (unsigned int) config_.layout_cols, (unsigned int) config_.layout_rows,
@@ -56,6 +57,54 @@ Hub75Driver::Hub75Driver(const Hub75Config &config) : config_(config), running_(
 }
 
 Hub75Driver::~Hub75Driver() { end(); }
+
+bool Hub75Driver::set_min_refresh_rate(uint16_t refresh_rate) {
+  if (running_) {
+    ESP_LOGW(TAG, "Cannot change refresh rate while the driver is running");
+    return false;
+  }
+  if (refresh_rate == 0) {
+    ESP_LOGE(TAG, "Refresh rate must be greater than zero");
+    return false;
+  }
+
+  config_.min_refresh_rate = refresh_rate;
+  return true;
+}
+
+bool Hub75Driver::set_output_clock_speed(Hub75ClockSpeed clock_speed) {
+  if (running_) {
+    ESP_LOGW(TAG, "Cannot change output clock while the driver is running");
+    return false;
+  }
+
+  config_.output_clock_speed = clock_speed;
+  return true;
+}
+
+bool Hub75Driver::set_pin_color_order(Hub75PinColorOrder order) {
+  if (running_) {
+    ESP_LOGW(TAG, "Cannot change color channel pins while the driver is running");
+    return false;
+  }
+
+  const int8_t upper[] = {original_pins_.r1, original_pins_.g1, original_pins_.b1};
+  const int8_t lower[] = {original_pins_.r2, original_pins_.g2, original_pins_.b2};
+  static constexpr uint8_t permutations[][3] = {
+      {0, 1, 2}, {0, 2, 1}, {1, 0, 2}, {1, 2, 0}, {2, 0, 1}, {2, 1, 0},
+  };
+  if (static_cast<uint8_t>(order) >= sizeof(permutations) / sizeof(permutations[0])) {
+    return false;
+  }
+  const auto& permutation = permutations[static_cast<uint8_t>(order)];
+  config_.pins.r1 = upper[permutation[0]];
+  config_.pins.g1 = upper[permutation[1]];
+  config_.pins.b1 = upper[permutation[2]];
+  config_.pins.r2 = lower[permutation[0]];
+  config_.pins.g2 = lower[permutation[1]];
+  config_.pins.b2 = lower[permutation[2]];
+  return true;
+}
 
 // ============================================================================
 // Initialization

--- a/components/hub75/src/drivers/fm6126a.cpp
+++ b/components/hub75/src/drivers/fm6126a.cpp
@@ -98,6 +98,14 @@ esp_err_t DriverInit::initialize(const Hub75Config &config) {
       fm6126a_init(config.pins, pixels_per_row);
       return ESP_OK;
 
+    case Hub75ShiftDriver::ICN2069:
+      // SRAM-based, hardware-PWM chip family (same as FM6363/FM6565S) — needs its
+      // own multi-register init + independent GCLK timing, NOT the FM6126A
+      // 2-register shift-only scheme. No working sequence confirmed yet; see
+      // https://github.com/hzeller/rpi-rgb-led-matrix/issues/466
+      ESP_LOGW(TAG, "ICN2069 initialization not yet implemented");
+      return ESP_ERR_NOT_SUPPORTED;
+
     case Hub75ShiftDriver::DP3246:
       dp3246_init(config.pins, pixels_per_row);
       return ESP_OK;

--- a/components/hub75/src/hub75_driver.h
+++ b/components/hub75/src/hub75_driver.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "hub75_config.h"
+#include "platforms/platform_dma.h"
+#include <memory>
+
+namespace hub75 {
+
+class Hub75Driver {
+ public:
+  Hub75Driver(const Hub75Config &config);
+  ~Hub75Driver();
+
+  bool begin();
+  void shutdown();
+
+  void set_brightness(uint8_t brightness);
+  void set_rotation(Hub75Rotation rotation);
+  void clear();
+  void fill(uint16_t x, uint16_t y, uint16_t w, uint16_t h, uint8_t r, uint8_t g, uint8_t b);
+  void draw_pixels(uint16_t x, uint16_t y, uint16_t w, uint16_t h, const uint8_t *buffer, Hub75PixelFormat format,
+                   Hub75ColorOrder color_order, bool big_endian);
+  void flip_buffer();
+  void set_frame_callback(Hub75FrameCallback callback, void *arg);
+
+  // Helper for single pixel set (wraps draw_pixels)
+  void set_pixel(uint16_t x, uint16_t y, uint8_t r, uint8_t g, uint8_t b) {
+    uint8_t buffer[3] = {r, g, b};
+    draw_pixels(x, y, 1, 1, buffer, Hub75PixelFormat::RGB888, Hub75ColorOrder::RGB, false);
+  }
+
+  PlatformDma *getDmaEngine() const { return dma_.get(); }
+
+ private:
+  std::unique_ptr<PlatformDma> dma_;
+  Hub75Config config_;
+};
+
+}  // namespace hub75

--- a/components/hub75/src/platforms/gdma/gdma_dma.cpp
+++ b/components/hub75/src/platforms/gdma/gdma_dma.cpp
@@ -198,6 +198,12 @@ bool GdmaDma::init() {
   LCD_CAM.lcd_misc.lcd_afifo_reset = 1;  // Reset LCD TX FIFO
 
   // Note: No EOF callback needed with descriptor-chain approach
+
+  // Register frame callback if already set
+  if (frame_callback_) {
+    gdma_tx_event_callbacks_t cbs = {.on_trans_eof = GdmaDma::on_trans_eof};
+    gdma_register_tx_event_callbacks(dma_chan_, &cbs, this);
+  }
   // The descriptor chain encodes all timing via repetition counts
 
   ESP_LOGI(TAG, "GDMA EOF callback registered successfully");
@@ -430,6 +436,28 @@ void GdmaDma::stop_transfer() {
   gdma_stop(dma_chan_);
 
   ESP_LOGI(TAG, "DMA transfer stopped");
+}
+
+void GdmaDma::set_frame_callback(Hub75FrameCallback callback, void *arg) {
+  PlatformDma::set_frame_callback(callback, arg);
+
+  if (dma_chan_) {
+    if (callback) {
+      gdma_tx_event_callbacks_t cbs = {.on_trans_eof = GdmaDma::on_trans_eof};
+      gdma_register_tx_event_callbacks(dma_chan_, &cbs, this);
+    } else {
+      gdma_tx_event_callbacks_t cbs = {.on_trans_eof = NULL};
+      gdma_register_tx_event_callbacks(dma_chan_, &cbs, NULL);
+    }
+  }
+}
+
+bool IRAM_ATTR GdmaDma::on_trans_eof(gdma_channel_handle_t dma_chan, gdma_event_data_t *event_data, void *user_data) {
+  auto *dma = static_cast<GdmaDma *>(user_data);
+  if (dma && dma->frame_callback_) {
+    return dma->frame_callback_(dma->frame_callback_arg_);
+  }
+  return false;
 }
 
 // No EOF callback needed - descriptor chain handles all timing

--- a/components/hub75/src/platforms/gdma/gdma_dma.cpp
+++ b/components/hub75/src/platforms/gdma/gdma_dma.cpp
@@ -135,17 +135,17 @@ bool GdmaDma::init() {
   configure_gpio();
 
   // Allocate GDMA channel
-  gdma_channel_alloc_config_t dma_alloc_config = {.sibling_chan = nullptr,
-                                                  .direction = GDMA_CHANNEL_DIRECTION_TX,
-                                                  .flags = {.reserve_sibling = 0
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
-                                                            ,
-                                                            .isr_cache_safe = 0
+  gdma_channel_alloc_config_t dma_alloc_config = {
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 4, 0)
+      .direction = GDMA_CHANNEL_DIRECTION_TX,
+      .flags = {.reserve_sibling = 0, .isr_cache_safe = 0}
+#else
+      .flags = {.isr_cache_safe = 0}
 #endif
-                                                  }};
+  };
 
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
-  esp_err_t err = gdma_new_ahb_channel(&dma_alloc_config, &dma_chan_);
+  esp_err_t err = gdma_new_ahb_channel(&dma_alloc_config, &dma_chan_, NULL);
 #else
   esp_err_t err = gdma_new_channel(&dma_alloc_config, &dma_chan_);
 #endif
@@ -201,7 +201,7 @@ bool GdmaDma::init() {
 
   // Register frame callback if already set
   if (frame_callback_) {
-    gdma_tx_event_callbacks_t cbs = {.on_trans_eof = GdmaDma::on_trans_eof};
+    gdma_tx_event_callbacks_t cbs = {.on_trans_eof = GdmaDma::on_trans_eof, .on_descr_err = NULL};
     gdma_register_tx_event_callbacks(dma_chan_, &cbs, this);
   }
   // The descriptor chain encodes all timing via repetition counts
@@ -443,10 +443,10 @@ void GdmaDma::set_frame_callback(Hub75FrameCallback callback, void *arg) {
 
   if (dma_chan_) {
     if (callback) {
-      gdma_tx_event_callbacks_t cbs = {.on_trans_eof = GdmaDma::on_trans_eof};
+      gdma_tx_event_callbacks_t cbs = {.on_trans_eof = GdmaDma::on_trans_eof, .on_descr_err = NULL};
       gdma_register_tx_event_callbacks(dma_chan_, &cbs, this);
     } else {
-      gdma_tx_event_callbacks_t cbs = {.on_trans_eof = NULL};
+      gdma_tx_event_callbacks_t cbs = {.on_trans_eof = NULL, .on_descr_err = NULL};
       gdma_register_tx_event_callbacks(dma_chan_, &cbs, NULL);
     }
   }

--- a/components/hub75/src/platforms/gdma/gdma_dma.cpp
+++ b/components/hub75/src/platforms/gdma/gdma_dma.cpp
@@ -135,17 +135,17 @@ bool GdmaDma::init() {
   configure_gpio();
 
   // Allocate GDMA channel
-  gdma_channel_alloc_config_t dma_alloc_config = {
-#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 4, 0)
-      .direction = GDMA_CHANNEL_DIRECTION_TX,
-      .flags = {.reserve_sibling = 0, .isr_cache_safe = 0}
-#else
-      .flags = {.isr_cache_safe = 0}
+  gdma_channel_alloc_config_t dma_alloc_config = {.sibling_chan = nullptr,
+                                                  .direction = GDMA_CHANNEL_DIRECTION_TX,
+                                                  .flags = {.reserve_sibling = 0
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+                                                            ,
+                                                            .isr_cache_safe = 0
 #endif
-  };
+                                                  }};
 
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
-  esp_err_t err = gdma_new_ahb_channel(&dma_alloc_config, &dma_chan_, NULL);
+  esp_err_t err = gdma_new_ahb_channel(&dma_alloc_config, &dma_chan_);
 #else
   esp_err_t err = gdma_new_channel(&dma_alloc_config, &dma_chan_);
 #endif
@@ -201,7 +201,7 @@ bool GdmaDma::init() {
 
   // Register frame callback if already set
   if (frame_callback_) {
-    gdma_tx_event_callbacks_t cbs = {.on_trans_eof = GdmaDma::on_trans_eof, .on_descr_err = NULL};
+    gdma_tx_event_callbacks_t cbs = {.on_trans_eof = GdmaDma::on_trans_eof};
     gdma_register_tx_event_callbacks(dma_chan_, &cbs, this);
   }
   // The descriptor chain encodes all timing via repetition counts
@@ -443,10 +443,10 @@ void GdmaDma::set_frame_callback(Hub75FrameCallback callback, void *arg) {
 
   if (dma_chan_) {
     if (callback) {
-      gdma_tx_event_callbacks_t cbs = {.on_trans_eof = GdmaDma::on_trans_eof, .on_descr_err = NULL};
+      gdma_tx_event_callbacks_t cbs = {.on_trans_eof = GdmaDma::on_trans_eof};
       gdma_register_tx_event_callbacks(dma_chan_, &cbs, this);
     } else {
-      gdma_tx_event_callbacks_t cbs = {.on_trans_eof = NULL, .on_descr_err = NULL};
+      gdma_tx_event_callbacks_t cbs = {.on_trans_eof = NULL};
       gdma_register_tx_event_callbacks(dma_chan_, &cbs, NULL);
     }
   }

--- a/components/hub75/src/platforms/gdma/gdma_dma.cpp
+++ b/components/hub75/src/platforms/gdma/gdma_dma.cpp
@@ -135,17 +135,31 @@ bool GdmaDma::init() {
   configure_gpio();
 
   // Allocate GDMA channel
-  gdma_channel_alloc_config_t dma_alloc_config = {.sibling_chan = nullptr,
-                                                  .direction = GDMA_CHANNEL_DIRECTION_TX,
-                                                  .flags = {.reserve_sibling = 0
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+  gdma_channel_alloc_config_t dma_alloc_config = {
+      .flags = {
+          .isr_cache_safe = 0,
+      },
+  };
+#else
+  gdma_channel_alloc_config_t dma_alloc_config = {
+      .sibling_chan = nullptr,
+      .direction = GDMA_CHANNEL_DIRECTION_TX,
+      .flags = {
+          .reserve_sibling = 0,
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
-                                                            ,
-                                                            .isr_cache_safe = 0
+          .isr_cache_safe = 0,
 #endif
-                                                  }};
+      },
+  };
+#endif
 
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+  esp_err_t err = gdma_new_ahb_channel(&dma_alloc_config, &dma_chan_, nullptr);
+#else
   esp_err_t err = gdma_new_ahb_channel(&dma_alloc_config, &dma_chan_);
+#endif
 #else
   esp_err_t err = gdma_new_channel(&dma_alloc_config, &dma_chan_);
 #endif
@@ -201,7 +215,10 @@ bool GdmaDma::init() {
 
   // Register frame callback if already set
   if (frame_callback_) {
-    gdma_tx_event_callbacks_t cbs = {.on_trans_eof = GdmaDma::on_trans_eof};
+    gdma_tx_event_callbacks_t cbs = {
+        .on_trans_eof = GdmaDma::on_trans_eof,
+        .on_descr_err = nullptr,
+    };
     gdma_register_tx_event_callbacks(dma_chan_, &cbs, this);
   }
   // The descriptor chain encodes all timing via repetition counts
@@ -443,10 +460,16 @@ void GdmaDma::set_frame_callback(Hub75FrameCallback callback, void *arg) {
 
   if (dma_chan_) {
     if (callback) {
-      gdma_tx_event_callbacks_t cbs = {.on_trans_eof = GdmaDma::on_trans_eof};
+      gdma_tx_event_callbacks_t cbs = {
+          .on_trans_eof = GdmaDma::on_trans_eof,
+          .on_descr_err = nullptr,
+      };
       gdma_register_tx_event_callbacks(dma_chan_, &cbs, this);
     } else {
-      gdma_tx_event_callbacks_t cbs = {.on_trans_eof = NULL};
+      gdma_tx_event_callbacks_t cbs = {
+          .on_trans_eof = nullptr,
+          .on_descr_err = nullptr,
+      };
       gdma_register_tx_event_callbacks(dma_chan_, &cbs, NULL);
     }
   }

--- a/components/hub75/src/platforms/gdma/gdma_dma.cpp
+++ b/components/hub75/src/platforms/gdma/gdma_dma.cpp
@@ -1109,6 +1109,11 @@ bool GdmaDma::build_descriptor_chain_internal(RowBitPlaneBuffer *buffers, dma_de
 
   // Link descriptors with BCM repetitions
   size_t desc_idx = 0;
+  const int configured_sync_row = config_.frame_sync_row;
+  const int sync_row =
+      (configured_sync_row >= 0 && configured_sync_row < num_rows_)
+          ? configured_sync_row
+          : (num_rows_ - 1);
   for (int row = 0; row < num_rows_; row++) {
     for (int bit = 0; bit < bit_depth_; bit++) {
       uint8_t *const bit_buffer = buffers[row].data + (bit * bytes_per_bitplane);
@@ -1135,11 +1140,17 @@ bool GdmaDma::build_descriptor_chain_internal(RowBitPlaneBuffer *buffers, dma_de
         desc_idx++;
       }
     }
+
+    // Keep exactly one EOF per refresh. On a single-buffer display this may
+    // sit just after a latency-sensitive region, leaving the remaining rows
+    // as a safe window to update that region before the chain wraps.
+    if (row == sync_row) {
+      descriptors[desc_idx - 1].dw0.suc_eof = 1;
+    }
   }
 
   // Last descriptor loops back to first (continuous refresh)
   descriptors[descriptor_count_ - 1].next = &descriptors[0];
-  descriptors[descriptor_count_ - 1].dw0.suc_eof = 1;  // Optional: EOF once per frame
 
   return true;
 }

--- a/components/hub75/src/platforms/gdma/gdma_dma.h
+++ b/components/hub75/src/platforms/gdma/gdma_dma.h
@@ -51,6 +51,10 @@ class GdmaDma : public PlatformDma {
    */
   void stop_transfer() override;
 
+  void set_frame_callback(Hub75FrameCallback callback, void *arg) override;
+
+  static bool IRAM_ATTR on_trans_eof(gdma_channel_handle_t dma_chan, gdma_event_data_t *event_data, void *user_data);
+
   /**
    * @brief Set basis brightness (override base class)
    */

--- a/components/hub75/src/platforms/gdma/gdma_dma.h
+++ b/components/hub75/src/platforms/gdma/gdma_dma.h
@@ -91,6 +91,12 @@ class GdmaDma : public PlatformDma {
    */
   void flip_buffer() override;
 
+  /**
+   * @brief Get GDMA channel handle for external callback registration
+   * @return GDMA channel handle, or NULL if not initialized
+   */
+  gdma_channel_handle_t getGdmaChannel() const { return dma_chan_; }
+
   // ============================================================================
   // Static Helper Functions (Public for compile-time validation)
   // ============================================================================

--- a/components/hub75/src/platforms/parlio/parlio_dma.cpp
+++ b/components/hub75/src/platforms/parlio/parlio_dma.cpp
@@ -28,6 +28,9 @@
 #include <esp_memory_utils.h>
 
 static const char *const TAG = "ParlioDma";
+static constexpr size_t kParlioMaxTransferBytes = 65534;  // Must be < 65535 per driver constraint
+static constexpr size_t kParlioMaxTransferBits = 65535;   // Conservative limit if API expects bits
+static constexpr size_t kParlioChunkMaxWords = 4080;      // Max safe chunk (must be even for 32-bit align)
 
 namespace hub75 {
 
@@ -87,16 +90,33 @@ ParlioDma::ParlioDma(const Hub75Config &config)
       front_idx_(0),
       active_idx_(0),
       is_double_buffered_(false),
+      total_buffer_bytes_(0),
+      total_buffer_words_(0),
+      chunk_words_(0),
+      chunk_count_(0),
+      chunks_per_frame_(0),
+      segment_count_(0),
+      segment_index_(0),
+      segment_offset_words_(0),
+      tx_queue_depth_(0),
+      tx_idx_(0),
+      pending_tx_idx_(0),
+      tx_swap_pending_(false),
+      completed_chunk_index_(0),
+      tx_task_(nullptr),
+      tx_task_started_(false),
       basis_brightness_(config.brightness),
       intensity_(1.0f),
       transfer_started_(false) {
   // Initialize transmit config
   // Note: For four-scan panels, dma_width_ is doubled and num_rows_ is halved
   // to match the physical shift register layout
-  transmit_config_.idle_value = 0x00;
+  // Ensure output is blanked during any idle gaps between queued chunks
+  // (OE=1, clock gate off by default)
+  transmit_config_.idle_value = (1 << OE_BIT);
   transmit_config_.bitscrambler_program = nullptr;
-  transmit_config_.flags.queue_nonblocking = 0;
-  transmit_config_.flags.loop_transmission = 1;  // Continuous refresh
+  transmit_config_.flags.queue_nonblocking = 1;
+  transmit_config_.flags.loop_transmission = 0;  // Use manual chunked queueing
 }
 
 ParlioDma::~ParlioDma() { ParlioDma::shutdown(); }
@@ -151,6 +171,21 @@ bool ParlioDma::init() {
   }
   ESP_LOGI(TAG, "PARLIO TX unit enabled");
 
+  // Register callbacks for chunked transmission BEFORE queueing (needed to keep queue fed)
+  parlio_tx_event_callbacks_t cbs = {.on_trans_done = ParlioDma::on_trans_done, .on_buffer_switched = NULL};
+  parlio_tx_unit_register_event_callbacks(tx_unit_, &cbs, this);
+
+  // Start task that feeds chunks on TX done notifications
+  if (!tx_task_started_) {
+    BaseType_t ok = xTaskCreatePinnedToCore(ParlioDma::tx_task_trampoline, "parlio_tx", 4096, this,
+                                            configMAX_PRIORITIES - 2, &tx_task_, 0);
+    if (ok != pdPASS) {
+      ESP_LOGE(TAG, "Failed to create PARLIO TX task");
+      return false;
+    }
+    tx_task_started_ = true;
+  }
+
   // Build transaction queue
   if (!build_transaction_queue()) {
     ESP_LOGE(TAG, "Failed to build transaction queue");
@@ -159,18 +194,19 @@ bool ParlioDma::init() {
 
   ESP_LOGI(TAG, "PARLIO TX initialized successfully with circular DMA");
 
-  // Register frame callback if already set
-  if (frame_callback_) {
-    parlio_tx_event_callbacks_t cbs = {.on_trans_done = NULL, .on_buffer_switched = ParlioDma::on_buffer_switched};
-    parlio_tx_unit_register_event_callbacks(tx_unit_, &cbs, this);
-  }
-
   return true;
 }
 
 void ParlioDma::shutdown() {
   if (transfer_started_) {
     ParlioDma::stop_transfer();
+  }
+
+  if (tx_task_started_ && tx_task_) {
+    TaskHandle_t task = tx_task_;
+    tx_task_ = nullptr;
+    tx_task_started_ = false;
+    vTaskDelete(task);
   }
 
   if (tx_unit_) {
@@ -241,7 +277,7 @@ void ParlioDma::configure_parlio() {
       .valid_start_delay = 0,
       .valid_stop_delay = 0,
       .trans_queue_depth = 4,  // Match ESP-IDF example (was: num_rows_ * bit_depth_)
-      .max_transfer_size = max_buffer_size * sizeof(uint16_t),
+      .max_transfer_size = std::min(max_buffer_size * sizeof(uint16_t), kParlioMaxTransferBytes),
       .dma_burst_size = 0,  // Default
       .sample_edge = PARLIO_SAMPLE_EDGE_POS,
       .bit_pack_order = PARLIO_BIT_PACK_ORDER_LSB,  // Explicit LSB to match ESP-IDF example
@@ -272,6 +308,7 @@ void ParlioDma::configure_parlio() {
   ESP_LOGI(TAG, "  Clock gating: NOT SUPPORTED");
 #endif
   ESP_LOGI(TAG, "  Transaction queue depth: %zu", config.trans_queue_depth);
+  tx_queue_depth_ = config.trans_queue_depth;
 }
 
 void ParlioDma::configure_gpio() {
@@ -384,6 +421,14 @@ bool ParlioDma::allocate_row_buffers() {
       bp.pixel_words = dma_width_;
       bp.padding_words = calculate_bcm_padding(bit);
       bp.total_words = bp.pixel_words + bp.padding_words;
+
+      // Ensure 32-bit alignment (even number of uint16_t words)
+      // ESP32-P4 PARLIO DMA requires 4-byte aligned start addresses
+      // Since buffers are packed contiguously, each buffer must be a multiple of 4 bytes
+      if (bp.total_words % 2 != 0) {
+        bp.padding_words++;
+        bp.total_words++;
+      }
 
       total_words += bp.total_words;
 
@@ -500,13 +545,8 @@ void ParlioDma::set_frame_callback(Hub75FrameCallback callback, void *arg) {
   PlatformDma::set_frame_callback(callback, arg);
 
   if (tx_unit_) {
-    if (callback) {
-      parlio_tx_event_callbacks_t cbs = {.on_trans_done = NULL, .on_buffer_switched = ParlioDma::on_buffer_switched};
-      parlio_tx_unit_register_event_callbacks(tx_unit_, &cbs, this);
-    } else {
-      parlio_tx_event_callbacks_t cbs = {.on_trans_done = NULL, .on_buffer_switched = NULL};
-      parlio_tx_unit_register_event_callbacks(tx_unit_, &cbs, NULL);
-    }
+    parlio_tx_event_callbacks_t cbs = {.on_trans_done = ParlioDma::on_trans_done, .on_buffer_switched = NULL};
+    parlio_tx_unit_register_event_callbacks(tx_unit_, &cbs, this);
   }
 }
 
@@ -518,6 +558,31 @@ bool IRAM_ATTR ParlioDma::on_buffer_switched(parlio_tx_unit_handle_t tx_unit,
     return dma->frame_callback_(dma->frame_callback_arg_);
   }
   return false;
+}
+
+bool IRAM_ATTR ParlioDma::on_trans_done(parlio_tx_unit_handle_t tx_unit,
+                                        const parlio_tx_done_event_data_t *event_data,
+                                        void *user_data) {
+  auto *dma = static_cast<ParlioDma *>(user_data);
+  if (!dma) {
+    return false;
+  }
+  BaseType_t higher_woken = pdFALSE;
+  if (dma->tx_task_) {
+    vTaskNotifyGiveFromISR(dma->tx_task_, &higher_woken);
+  }
+
+  // Track completed chunks to detect frame boundary in ISR
+  dma->completed_chunk_index_++;
+  if (dma->completed_chunk_index_ >= dma->chunks_per_frame_) {
+    dma->completed_chunk_index_ = 0;
+    if (dma->frame_callback_) {
+      const bool cb_yield = dma->frame_callback_(dma->frame_callback_arg_);
+      return (higher_woken == pdTRUE) || cb_yield;
+    }
+  }
+
+  return higher_woken == pdTRUE;
 }
 
 void ParlioDma::initialize_buffer_internal(BitPlaneBuffer *buffers) {
@@ -795,25 +860,49 @@ bool ParlioDma::build_transaction_queue() {
     return false;
   }
 
-  ESP_LOGD(TAG, "Starting loop transmission...");
+  ESP_LOGI(TAG, "Starting chunked transmission...");
 
   // Use cached buffer size (computed once in allocate_row_buffers)
-  size_t total_words = total_buffer_bytes_ / sizeof(uint16_t);
-  size_t total_bits = total_buffer_bytes_ * 8;  // Convert bytes to bits
-
-  ESP_LOGD(TAG, "Transmitting entire buffer: %zu words (%zu bytes, %zu bits)", total_words, total_buffer_bytes_,
-           total_bits);
-  ESP_LOGD(TAG, "Buffer start address: %p (front buffer [%d])", dma_buffers_[front_idx_], front_idx_);
-
-  // Start loop transmission with front buffer (ESP-IDF example calls transmit ONCE with loop_transmission=true)
-  esp_err_t err = parlio_tx_unit_transmit(tx_unit_, dma_buffers_[front_idx_], total_bits, &transmit_config_);
-  if (err != ESP_OK) {
-    ESP_LOGE(TAG, "Failed to start loop transmission: %s", esp_err_to_name(err));
-    ESP_LOGE(TAG, "  Buffer: %p, bits: %zu", dma_buffers_[front_idx_], total_bits);
+  total_buffer_words_ = total_buffer_bytes_ / sizeof(uint16_t);
+  chunk_words_ = std::min(total_buffer_words_, kParlioChunkMaxWords);
+  if (chunk_words_ == 0) {
+    ESP_LOGE(TAG, "Invalid chunk size");
     return false;
   }
+  chunk_count_ = (total_buffer_words_ + chunk_words_ - 1) / chunk_words_;
+  segment_count_ = static_cast<size_t>(num_rows_) * static_cast<size_t>(bit_depth_);
+  segment_index_ = 0;
+  segment_offset_words_ = 0;
+  chunks_per_frame_ = 0;
+  for (size_t i = 0; i < segment_count_; i++) {
+    const BitPlaneBuffer &bp = row_buffers_[front_idx_][i];
+    chunks_per_frame_ += (bp.total_words + chunk_words_ - 1) / chunk_words_;
+  }
+  completed_chunk_index_ = 0;
+  tx_idx_ = front_idx_;
+  pending_tx_idx_ = tx_idx_;
+  tx_swap_pending_ = false;
 
-  ESP_LOGI(TAG, "Loop transmission started successfully");
+  const size_t total_bits = total_buffer_bytes_ * 8;  // Convert bytes to bits
+
+  ESP_LOGI(TAG, "Transmitting buffer in chunks: %zu words (%zu bytes, %zu bits)", total_buffer_words_,
+           total_buffer_bytes_, total_bits);
+  ESP_LOGI(TAG, "Chunk size: %zu words, chunks/frame: %zu, queue depth: %zu", chunk_words_, chunk_count_,
+           tx_queue_depth_);
+  ESP_LOGI(TAG, "Buffer start address: %p (tx buffer [%d])", dma_buffers_[tx_idx_], tx_idx_);
+  ESP_LOGI(TAG, "First chunk: %zu words (%zu bytes, %zu bits)", chunk_words_,
+           chunk_words_ * sizeof(uint16_t), chunk_words_ * 16);
+
+  // Prime the queue with initial chunks
+  const size_t prime_count = std::min(tx_queue_depth_, chunk_count_);
+  for (size_t i = 0; i < prime_count; i++) {
+    if (!queue_next_chunk(false)) {
+      ESP_LOGE(TAG, "Failed to queue chunk %zu/%zu", i + 1, prime_count);
+      return false;
+    }
+  }
+
+  ESP_LOGI(TAG, "Chunked transmission started successfully");
 
   return true;
 }
@@ -1085,11 +1174,85 @@ void ParlioDma::flip_buffer() {
   // Swap indices (front ↔ active)
   std::swap(front_idx_, active_idx_);
 
-  // Queue new front buffer (hardware switches seamlessly after current frame)
-  size_t total_bits = total_buffer_bytes_ * 8;
-  esp_err_t err = parlio_tx_unit_transmit(tx_unit_, dma_buffers_[front_idx_], total_bits, &transmit_config_);
+  // Defer hardware buffer switch to frame boundary (handled in on_trans_done)
+  pending_tx_idx_ = front_idx_;
+  tx_swap_pending_ = true;
+}
+
+bool ParlioDma::queue_next_chunk(bool invoke_frame_callback) {
+  if (!tx_unit_) {
+    if (!invoke_frame_callback) {
+      ESP_LOGE(TAG, "queue_next_chunk: tx_unit_ is null");
+    }
+    return false;
+  }
+  if (total_buffer_words_ == 0 || chunk_words_ == 0 || segment_count_ == 0) {
+    if (!invoke_frame_callback) {
+      ESP_LOGE(TAG,
+               "queue_next_chunk: invalid sizes total_words=%zu chunk_words=%zu segments=%zu",
+               total_buffer_words_, chunk_words_, segment_count_);
+    }
+    return false;
+  }
+
+  // Use segment (bit-plane) boundaries to avoid chunk splits mid-plane
+  BitPlaneBuffer &bp = row_buffers_[tx_idx_][segment_index_];
+  const size_t remaining = bp.total_words - segment_offset_words_;
+  const size_t words = std::min(chunk_words_, remaining);
+  const size_t bits = words * 16;
+  uint16_t *chunk_ptr = bp.data + segment_offset_words_;
+
+  // Debug alignment
+  static int debug_chunks = 0;
+  if (debug_chunks < 10) {
+      ESP_LOGI(TAG, "Chunk %d: ptr=%p (align=%lu), words=%zu, bits=%zu, offset=%zu",
+               debug_chunks, chunk_ptr, ((uint32_t)chunk_ptr) & 3, words, bits, segment_offset_words_);
+      debug_chunks++;
+  }
+
+  esp_err_t err = parlio_tx_unit_transmit(tx_unit_, chunk_ptr, bits, &transmit_config_);
   if (err != ESP_OK) {
-    ESP_LOGW(TAG, "flip_buffer: Failed to queue buffer: %s", esp_err_to_name(err));
+    if (!invoke_frame_callback) {
+      ESP_LOGE(TAG,
+           "queue_next_chunk: transmit failed: %s (segment=%zu/%zu, offset=%zu, words=%zu, bits=%zu, ptr=%p)",
+           esp_err_to_name(err), segment_index_ + 1, segment_count_, segment_offset_words_, words, bits, chunk_ptr);
+    }
+    return false;
+  }
+
+  if (words == remaining) {
+    segment_offset_words_ = 0;
+    segment_index_++;
+    if (segment_index_ >= segment_count_) {
+      segment_index_ = 0;
+
+      if (tx_swap_pending_) {
+        tx_idx_ = pending_tx_idx_;
+        tx_swap_pending_ = false;
+      }
+    }
+  } else {
+    segment_offset_words_ += words;
+  }
+
+  return true;
+}
+
+void ParlioDma::tx_task_trampoline(void *arg) {
+  auto *dma = static_cast<ParlioDma *>(arg);
+  if (dma) {
+    dma->tx_task_loop();
+  }
+  vTaskDelete(NULL);
+}
+
+void ParlioDma::tx_task_loop() {
+  while (true) {
+    ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
+    if (!queue_next_chunk(false)) {
+      // If transmit fails, avoid tight loop
+      vTaskDelay(pdMS_TO_TICKS(1));
+    }
   }
 }
 

--- a/components/hub75/src/platforms/parlio/parlio_dma.cpp
+++ b/components/hub75/src/platforms/parlio/parlio_dma.cpp
@@ -375,11 +375,11 @@ void ParlioDma::configure_gpio() {
   // PARLIO handles GPIO routing internally based on data_gpio_nums
   // We only need to set drive strength for better signal integrity
 
-  gpio_num_t all_pins[] = {(gpio_num_t) config_.pins.r1, (gpio_num_t) config_.pins.g1,  (gpio_num_t) config_.pins.b1,
-                           (gpio_num_t) config_.pins.r2, (gpio_num_t) config_.pins.g2,  (gpio_num_t) config_.pins.b2,
-                           (gpio_num_t) config_.pins.a,  (gpio_num_t) config_.pins.b,   (gpio_num_t) config_.pins.c,
-                           (gpio_num_t) config_.pins.d,  (gpio_num_t) config_.pins.lat, (gpio_num_t) config_.pins.oe,
-                           (gpio_num_t) config_.pins.clk};
+  gpio_num_t all_pins[] = {(gpio_num_t) config_.pins.r1,  (gpio_num_t) config_.pins.g1,  (gpio_num_t) config_.pins.b1,
+                           (gpio_num_t) config_.pins.r2,  (gpio_num_t) config_.pins.g2,  (gpio_num_t) config_.pins.b2,
+                           (gpio_num_t) config_.pins.a,   (gpio_num_t) config_.pins.b,   (gpio_num_t) config_.pins.c,
+                           (gpio_num_t) config_.pins.d,   (gpio_num_t) config_.pins.e,   (gpio_num_t) config_.pins.lat,
+                           (gpio_num_t) config_.pins.oe,  (gpio_num_t) config_.pins.clk};
 
   for (auto pin : all_pins) {
     if (pin >= 0) {
@@ -560,15 +560,19 @@ bool ParlioDma::allocate_row_buffers() {
       // Continue with single buffer mode
       ESP_LOGW(TAG, "Continuing in single-buffer mode");
     } else {
-      // Assign pointers within buffer allocation
+      // Assign pointers within buffer allocation.
+      // Copy aligned sizes from buffer[0] rather than recomputing: recomputing
+      // skips the 32-bit alignment padding applied in the first pass, producing
+      // misaligned data pointers for every subsequent bit plane in buffer[1].
       current_ptr = dma_buffers_[1];
       for (int row = 0; row < num_rows_; row++) {
         for (int bit = 0; bit < bit_depth_; bit++) {
           int idx = (row * bit_depth_) + bit;
           BitPlaneBuffer &bp = row_buffers_[1][idx];
-          bp.pixel_words = dma_width_;
-          bp.padding_words = calculate_bcm_padding(bit);
-          bp.total_words = bp.pixel_words + bp.padding_words;
+          const BitPlaneBuffer &bp0 = row_buffers_[0][idx];
+          bp.pixel_words = bp0.pixel_words;
+          bp.padding_words = bp0.padding_words;
+          bp.total_words = bp0.total_words;
           bp.data = current_ptr;
           current_ptr += bp.total_words;
         }
@@ -673,33 +677,19 @@ void ParlioDma::initialize_buffer_internal(BitPlaneBuffer *buffers) {
       // use row 31's address because descriptor chains have no padding period.
 
       // Initialize pixel section (LAT on last pixel)
-      for (size_t x = 0; x < bp.pixel_words; x++) {
-        uint16_t word = 0;
+      uint16_t base_word = 0;
 #ifdef SOC_PARLIO_TX_CLK_SUPPORT_GATING
-        word |= (1 << CLK_GATE_BIT);  // MSB=1: enable clock during pixel shift (clock gating)
+      base_word |= static_cast<uint16_t>(1 << CLK_GATE_BIT);
 #endif
-        word |= (row_addr << ADDR_SHIFT);  // Row address
-        word |= (1 << OE_BIT);             // OE=1 (blanked during shift)
-
-        // LAT pulse on last pixel
-        if (x == bp.pixel_words - 1) {
-          word |= (1 << LAT_BIT);
-        }
-
-        // RGB data = 0 (will be set by draw_pixels)
-        bp.data[x] = word;
-      }
+      base_word |= static_cast<uint16_t>(row_addr << ADDR_SHIFT);
+      base_word |= static_cast<uint16_t>(1 << OE_BIT);
+      std::fill(bp.data, bp.data + bp.pixel_words, base_word);
+      bp.data[bp.pixel_words - 1] |= static_cast<uint16_t>(1 << LAT_BIT);
 
       // Initialize padding section (BCM display time)
-      // When clock gating supported: MSB=0 disables clock, panel displays latched data
-      // When clock gating NOT supported: padding still needed for BCM timing via buffer length
-      for (size_t i = 0; i < bp.padding_words; i++) {
-        uint16_t word = 0;                 // MSB=0 always (clock disabled if gating supported, unused otherwise)
-        word |= (row_addr << ADDR_SHIFT);  // Row address
-        word |= (1 << OE_BIT);             // Default: blanked (will be adjusted by brightness)
-
-        bp.data[bp.pixel_words + i] = word;
-      }
+      // MSB=0: clock disabled if gating supported; unused otherwise
+      const uint16_t pad_word = static_cast<uint16_t>(row_addr << ADDR_SHIFT) | static_cast<uint16_t>(1 << OE_BIT);
+      std::fill(bp.data + bp.pixel_words, bp.data + bp.total_words, pad_word);
     }
   }
 }
@@ -770,112 +760,64 @@ void ParlioDma::set_brightness_oe_internal(BitPlaneBuffer *buffers, uint8_t brig
   // User sees smooth dimming; internally we never go below the minimum.
   const int effective_brightness = min_brightness + ((brightness * (255 - min_brightness)) / 255);
 
-  for (int row = 0; row < num_rows_; row++) {
-    for (int bit = 0; bit < bit_depth_; bit++) {
-      BitPlaneBuffer &bp = buffers[(row * bit_depth_) + bit];
+  // Outer loop over bit planes so per-bit calculations are computed once across all rows.
+  // padding_words/pixel_words are identical for every row at the same bit index.
+  for (int bit = 0; bit < bit_depth_; bit++) {
+    // Use row-0 buffer to read bit-level constants (same for all rows)
+    const BitPlaneBuffer &bp0 = buffers[bit];
 
-      // For PARLIO with clock gating, brightness is controlled by OE duty cycle
-      // in the padding section (where MSB=0 and panel displays)
+    if (bp0.padding_words == 0) {
+      continue;  // No padding for this bit plane, skip all rows
+    }
 
-      if (bp.padding_words == 0) {
-        continue;  // No padding, skip
-      }
+    const int padding_available = static_cast<int>(bp0.padding_words) - config_.latch_blanking;
 
-      // CRITICAL: PARLIO Brightness Timing
-      //
-      // Unlike GDMA (which transmits constant-width buffer with repetitions),
-      // PARLIO transmits variable-width padding with NO repetitions.
-      //
-      // Example bit 7 with 50% brightness:
-      //   GDMA: 30 pixels enabled × 32 reps = 960 pixel-clocks (duty cycle 30/61 per transmission)
-      //   PARLIO: Must enable 960 words over 1952-word padding (duty cycle 960/1952 = 49.2%)
-      //
-      // Key insight: Duty cycle must match to achieve same total display time
-      // Formula: Scale padding by duty cycle factor (adjusted_base_pixels / base_pixels)
+    int max_display;
+    if (bit <= lsbMsbTransitionBit_) {
+      const int bitplane = bit_depth_ - 1 - bit;
+      const int bitshift = (bit_depth_ - lsbMsbTransitionBit_ - 1) >> 1;
+      const int rightshift = std::max(bitplane - bitshift - 2, 0);
+      max_display = padding_available >> rightshift;
+    } else {
+      max_display = padding_available;
+    }
 
-      const int padding_available = bp.padding_words - config_.latch_blanking;
-
-      // PARLIO Hybrid BCM Approach
-      //
-      // PARLIO differs from GDMA/I2S: BCM timing comes from PADDING SIZE, not descriptor
-      // repetitions. Each bit plane has different padding (bit 7 has 32x more than bit 2).
-      //
-      // This creates a TWO-TIER system:
-      //
-      // MSB bits (> lsbMsbTransitionBit): Padding size provides BCM weighting
-      //   - Bit 7 has 32x more padding than bit 2 → inherently 32x longer display time
-      //   - Using rightshift here would DOUBLE-WEIGHT them (padding ratio × OE ratio)
-      //   - Solution: Use full padding_available, let padding size control BCM
-      //
-      // LSB bits (≤ lsbMsbTransitionBit): All have IDENTICAL padding (base_padding)
-      //   - Without differentiation, bits 0 and 1 would contribute equally → wrong colors
-      //   - Solution: Apply rightshift to reduce max_display for lower bits
-      //   - Same formula as GDMA/I2S for these bits
-      int max_display;
-      if (bit <= lsbMsbTransitionBit_) {
-        // LSB bits: identical padding, need rightshift for BCM differentiation
-        const int bitplane = bit_depth_ - 1 - bit;
-        const int bitshift = (bit_depth_ - lsbMsbTransitionBit_ - 1) >> 1;
-        const int rightshift = std::max(bitplane - bitshift - 2, 0);
-        max_display = padding_available >> rightshift;
-      } else {
-        // MSB bits: padding size provides BCM timing, no rightshift needed
-        max_display = padding_available;
-      }
-
-      // Safety check: ensure we have enough headroom for safety margin
-      if (max_display < 2) {
-        // Keep all padding blanked (OE=1) since we can't create a safe display window
+    if (max_display < 2) {
+      for (int row = 0; row < num_rows_; row++) {
+        BitPlaneBuffer &bp = buffers[(row * bit_depth_) + bit];
         for (size_t i = 0; i < bp.padding_words; i++) {
           bp.data[bp.pixel_words + i] |= (1 << OE_BIT);
         }
-        continue;
       }
+      continue;
+    }
 
-      int display_count = (max_display * effective_brightness) >> 8;
+    int display_count = (max_display * effective_brightness) >> 8;
 
-      // Safety net: Hybrid minimum for edge cases (e.g., 12-bit depth, unusual latch_blanking)
-      //
-      // The brightness floor above should prevent display_count=0 for most cases.
-      // This catches edge cases where high rightshift values (at higher bit depths)
-      // could still result in display_count=0 for lower bits.
-      //
-      // Gradually include more bits: at low brightness only MSB gets minimum=1,
-      // preserving color ratios for visible bits. As brightness increases, more
-      // bits naturally exceed 0 anyway.
-      // Formula: min_bit = (bit_depth-1) - (brightness/16)
-      //   brightness 1-15:  only bit 7 gets minimum
-      //   brightness 16-31: bits 6-7 get minimum
-      //   brightness 32-47: bits 5-7 get minimum, etc.
-      const int min_bit_for_display = std::max(0, bit_depth_ - 1 - (effective_brightness >> 4));
-      if (effective_brightness > 0 && display_count == 0 && bit >= min_bit_for_display) {
-        display_count = 1;
-      }
+    const int min_bit_for_display = std::max(0, bit_depth_ - 1 - (effective_brightness >> 4));
+    if (effective_brightness > 0 && display_count == 0 && bit >= min_bit_for_display) {
+      display_count = 1;
+    }
 
-      // Safety margin: prevent ghosting by keeping at least 1 pixel blanked
-      display_count = std::min(display_count, max_display - 1);
+    display_count = std::min(display_count, max_display - 1);
 
-      // Center the display window in padding section
-      const size_t start_display = (bp.padding_words - display_count) / 2;
-      const size_t end_display = start_display + display_count;
+    const size_t start_display = (bp0.padding_words - static_cast<size_t>(display_count)) / 2;
+    const size_t end_display = start_display + static_cast<size_t>(display_count);
 
-      // Set OE bits in padding section
+    for (int row = 0; row < num_rows_; row++) {
+      BitPlaneBuffer &bp = buffers[(row * bit_depth_) + bit];
+      uint16_t *pad = bp.data + bp.pixel_words;
+
       for (size_t i = 0; i < bp.padding_words; i++) {
-        uint16_t &word = bp.data[bp.pixel_words + i];
-
         if (i >= start_display && i < end_display) {
-          // Display enabled: OE=0
-          word &= OE_CLEAR_MASK;
+          pad[i] &= OE_CLEAR_MASK;
         } else {
-          // Blanked: OE=1
-          word |= (1 << OE_BIT);
+          pad[i] |= static_cast<uint16_t>(1 << OE_BIT);
         }
       }
 
-      // CRITICAL: Latch blanking at end of padding
-      // Blank last N words to prevent ghosting during row transition
-      for (size_t i = 0; i < config_.latch_blanking && i < bp.padding_words; i++) {
-        bp.data[bp.pixel_words + bp.padding_words - 1 - i] |= (1 << OE_BIT);
+      for (size_t i = 0; i < static_cast<size_t>(config_.latch_blanking) && i < bp.padding_words; i++) {
+        pad[bp.padding_words - 1 - i] |= static_cast<uint16_t>(1 << OE_BIT);
       }
     }
   }
@@ -1221,46 +1163,49 @@ HUB75_IRAM void ParlioDma::fill(uint16_t x, uint16_t y, uint16_t w, uint16_t h, 
   // Check if we can use identity fast path (no coordinate transforms needed)
   const bool identity_transform = (rotation_ == Hub75Rotation::ROTATE_0) && !needs_layout_remap_ && !needs_scan_remap_;
 
-  // Fill loop
-  for (uint16_t dy = 0; dy < h; dy++) {
-    for (uint16_t dx = 0; dx < w; dx++) {
-      uint16_t px = x + dx;
-      uint16_t py = y + dy;
+  // Fill loop — identity path uses dy→bit→dx order for sequential PSRAM access
+  if (identity_transform) {
+    for (uint16_t dy = 0; dy < h; dy++) {
+      const uint16_t py = y + dy;
       uint16_t row;
       bool is_lower;
-
-      // Fast path: identity transform (no rotation, standard layout, standard scan)
-      if (identity_transform) {
-        if (py < num_rows_) {
-          row = py;
-          is_lower = false;
-        } else {
-          row = py - num_rows_;
-          is_lower = true;
-        }
+      if (py < num_rows_) {
+        row = py;
+        is_lower = false;
       } else {
-        // Full coordinate transformation pipeline
+        row = py - num_rows_;
+        is_lower = true;
+      }
+      const uint16_t rgb_mask =
+          is_lower ? static_cast<uint16_t>(~RGB_LOWER_MASK) : static_cast<uint16_t>(~RGB_UPPER_MASK);
+      const uint16_t *patterns = is_lower ? lower_patterns : upper_patterns;
+      const int row_base_idx = row * bit_depth_;
+      for (int bit = 0; bit < bit_depth_; bit++) {
+        BitPlaneBuffer &bp = target_buffers[row_base_idx + bit];
+        const uint16_t pattern = patterns[bit];
+        uint16_t *row_ptr = bp.data + x;
+        for (uint16_t dx = 0; dx < w; dx++) {
+          row_ptr[dx] = (row_ptr[dx] & rgb_mask) | pattern;
+        }
+      }
+    }
+  } else {
+    for (uint16_t dy = 0; dy < h; dy++) {
+      for (uint16_t dx = 0; dx < w; dx++) {
+        uint16_t px = x + dx;
+        uint16_t py = y + dy;
         auto transformed = transform_coordinate(px, py, rotation_, needs_layout_remap_, needs_scan_remap_, layout_,
                                                 scan_wiring_, panel_width_, panel_height_, layout_rows_, layout_cols_,
                                                 virtual_width_, virtual_height_, dma_width_, num_rows_);
         px = transformed.x;
-        row = transformed.row;
-        is_lower = transformed.is_lower;
-      }
-
-      // Update all bit planes using pre-computed patterns
-      const int row_base_idx = row * bit_depth_;
-      for (int bit = 0; bit < bit_depth_; bit++) {
-        BitPlaneBuffer &bp = target_buffers[row_base_idx + bit];
-        uint16_t word = bp.data[px];  // Read existing word (preserves control bits)
-
-        if (is_lower) {
-          word = (word & ~RGB_LOWER_MASK) | lower_patterns[bit];
-        } else {
-          word = (word & ~RGB_UPPER_MASK) | upper_patterns[bit];
+        const int row_base_idx = transformed.row * bit_depth_;
+        const uint16_t rgb_mask = transformed.is_lower ? static_cast<uint16_t>(~RGB_LOWER_MASK)
+                                                       : static_cast<uint16_t>(~RGB_UPPER_MASK);
+        const uint16_t *patterns = transformed.is_lower ? lower_patterns : upper_patterns;
+        for (int bit = 0; bit < bit_depth_; bit++) {
+          BitPlaneBuffer &bp = target_buffers[row_base_idx + bit];
+          bp.data[px] = (bp.data[px] & rgb_mask) | patterns[bit];
         }
-
-        bp.data[px] = word;
       }
     }
   }

--- a/components/hub75/src/platforms/parlio/parlio_dma.h
+++ b/components/hub75/src/platforms/parlio/parlio_dma.h
@@ -39,6 +39,12 @@ class ParlioDma : public PlatformDma {
   void shutdown() override;
   void start_transfer() override;
   void stop_transfer() override;
+  void set_frame_callback(Hub75FrameCallback callback, void *arg) override;
+
+  static bool IRAM_ATTR on_buffer_switched(parlio_tx_unit_handle_t tx_unit,
+                                           const parlio_tx_buffer_switched_event_data_t *event_data,
+                                           void *user_data);
+
   void set_basis_brightness(uint8_t brightness) override;
   void set_intensity(float intensity) override;
   void set_rotation(Hub75Rotation rotation) override;

--- a/components/hub75/src/platforms/parlio/parlio_dma.h
+++ b/components/hub75/src/platforms/parlio/parlio_dma.h
@@ -49,6 +49,9 @@ class ParlioDma : public PlatformDma {
   void fill(uint16_t x, uint16_t y, uint16_t w, uint16_t h, uint8_t r, uint8_t g, uint8_t b) override;
   void flip_buffer() override;
 
+  // Get underlying PARLIO TX unit handle (for frame sync callbacks)
+  parlio_tx_unit_handle_t getTxUnitHandle() const { return tx_unit_; }
+
   struct BitPlaneBuffer {
     uint16_t *data;
     size_t pixel_words;

--- a/components/hub75/src/platforms/platform_dma.h
+++ b/components/hub75/src/platforms/platform_dma.h
@@ -32,7 +32,24 @@ class PlatformDma {
  public:
   virtual ~PlatformDma() = default;
 
+  /**
+   * @brief Register a callback to be called on each frame completion
+   *
+   * This callback is executed from an ISR (Interrupt Service Routine).
+   * Code in the callback should be minimal and IRAM_ATTR safe.
+   *
+   * @param callback Function to call
+   * @param arg Argument to pass to the callback
+   */
+  virtual void set_frame_callback(Hub75FrameCallback callback, void *arg) {
+    frame_callback_ = callback;
+    frame_callback_arg_ = arg;
+  }
+
  protected:
+   Hub75FrameCallback frame_callback_ = nullptr;
+   void *frame_callback_arg_ = nullptr;
+
   /**
    * @brief Protected constructor - initializes LUT based on config
    * @param config Hub75 configuration with gamma mode and bit depth

--- a/docs/FRAME_SYNC.md
+++ b/docs/FRAME_SYNC.md
@@ -1,0 +1,152 @@
+# Frame Synchronization
+
+The ESP-HUB75 driver supports hardware-based frame synchronization to eliminate visual artifacts like tearing and jitter during fast animations.
+
+By registering a callback, your application can be notified exactly when the hardware has finished transmitting a full frame to the display. This allows you to synchronize your rendering loop with the refresh rate of the panel (similar to VSYNC).
+
+## Why is this needed?
+
+The LED matrix refreshes at a high rate (typically >100Hz) asynchronously from your application code.
+- **Without synchronization**: If you update the display buffer while the hardware is in the middle of sending a frame, "tearing" occurs (part of the old frame and part of the new frame are shown simultaneously).
+- **With synchronization**: You wait for a frame to complete, then update the buffer content during the blanking interval or swap buffers immediately before the next frame starts.
+
+## Supported Platforms
+
+| Platform | Mechanism | Status |
+|----------|-----------|--------|
+| **ESP32-S3** | GDMA EOF (End of Frame) Interrupt | ✅ Supported |
+| **ESP32-P4** | PARLIO Buffer Switch / Transmit Done | ✅ Supported |
+| **ESP32-C6** | PARLIO Buffer Switch / Transmit Done | ✅ Supported |
+| **ESP32/S2** | I2S EOF Interrupt | ❌ Not yet implemented |
+
+## Usage
+
+### 1. Define the Callback
+
+The callback is executed in **ISR (Interrupt Service Routine) context**. Keep the code minimal. Do not use blocking operations, `printf`, or heavy logic.
+
+The recommended pattern is to signal a notification or semaphore to wake up your main task.
+
+```cpp
+#include "hub75.h"
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+
+// Semaphore to signal main task
+SemaphoreHandle_t frame_sync_sem = NULL;
+
+// Callback function (returns true to request context switch)
+bool IRAM_ATTR my_frame_callback(void *arg) {
+    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+    if (frame_sync_sem) {
+        xSemaphoreGiveFromISR(frame_sync_sem, &xHigherPriorityTaskWoken);
+    }
+    return xHigherPriorityTaskWoken == pdTRUE;
+}
+```
+
+### 2. Register the Callback
+
+Register the callback after initializing the driver.
+
+**Using `Hub75Driver` directly:**
+
+```cpp
+Hub75Driver driver(config);
+driver.begin();
+
+// Register callback
+driver.set_frame_callback(my_frame_callback, NULL);
+```
+
+
+### 3. Synchronize Your Loop
+
+In your animation task, wait for the semaphore before drawing or swapping buffers.
+
+```cpp
+void animation_task(void *pvParam) {
+    frame_sync_sem = xSemaphoreCreateBinary();
+    
+    // Register callback (as shown above)
+    // ...
+
+    for (;;) {
+        // 1. Prepare next frame content (draw to back buffer)
+        draw_animation();
+
+        // 2. Wait for hardware VSYNC
+        // Wait for the semaphore signaled by the ISR
+        if (xSemaphoreTake(frame_sync_sem, pdMS_TO_TICKS(50)) == pdTRUE) {
+            // 3. Swap buffers immediately after frame boundary
+             matrix.flipDMABuffer();
+        } else {
+             // Timeout (hardware not running?)
+        }
+    }
+}
+```
+
+## Timing Considerations
+
+The timing between the "End of Frame" signal and the start of the next frame is extremely tight (often just a few microseconds).
+
+**Incorrect Approach:**
+Waiting for the sync signal and *then* drawing pixels will result in a frame rate drop, as the display hardware will idle or repeat the previous frame while you draw.
+
+**Correct Approach:**
+1.  **Draw first**: Render your animation to the back buffer totally asynchronously.
+2.  **Wait**: Block on the semaphore until the hardware says "Frame Done".
+3.  **Flip immediately**: Perform the buffer swap (`flipDMABuffer()`) instantly.
+
+This ensures that the new buffer is ready exactly when the hardware is ready to accept it, ensuring 0-latency updates and maximum brightness.
+
+## Understanding Refresh Rate
+
+The physical refresh rate of the panel is constant and determined by the hardware configuration, not your drawing speed. It is influenced by:
+
+1.  **Clock Speed**: The speed at which data is shifted into the panels (default 20MHz). Higher is faster.
+2.  **Color Depth**: The number of bits per color channel (e.g., 8-bit vs 12-bit).
+    *   The driver uses Binary Code Modulation (BCM). To display 8 bits of color, it must refresh the screen 8 times (with varying durations) for a single "perceived" frame.
+    *   **Lowering bit depth** dramatically increases refresh rate.
+3.  **Resolution & Scan Mode**:
+    *   Total number of pixels in the chain.
+    *   1/32 scan panels require more shifting per frame than 1/16 scan panels.
+
+**Approximate Relationship:**
+$$ FPS \propto \frac{ClockFrequency}{Width \times Height \times ColorDepth} $$
+
+If you encounter flickering or low refresh rates, try:
+*   Increasing the clock speed (if the cable/panel supports it).
+*   Reducing the color depth (e.g., from default to lower precision if acceptable).
+
+## API Reference
+
+### `Hub75FrameCallback`
+
+Type definition for the callback function pointer.
+
+```cpp
+typedef bool (*Hub75FrameCallback)(void *arg);
+```
+
+*   **Returns**: `bool`. Return `true` if a high-priority task was woken (requires context switch), `false` otherwise.
+*   **Arg**: User argument pointer passed during registration.
+
+### `set_frame_callback`
+
+Registers or unregisters the callback.
+
+```cpp
+void set_frame_callback(Hub75FrameCallback callback, void *arg);
+```
+
+*   **callback**: The function to call. Pass `NULL` to disable/unregister.
+*   **arg**: Optional argument passed to the callback.
+
+## Implementation Details
+
+*   **ESP32-S3 (GDMA)**: Hooks into the `on_trans_eof` event of the GDMA engine. Triggers when the last descriptor in the chain (frame end) is processed.
+*   **ESP32-P4/C6 (PARLIO)**: Hooks into the `on_buffer_switched` (P4) or transaction completion events.
+
+The driver handles the low-level ISR registration logic internally, ensuring the callback is attached to the correct hardware channel/unit.

--- a/docs/FRAME_SYNC.md
+++ b/docs/FRAME_SYNC.md
@@ -15,8 +15,8 @@ The LED matrix refreshes at a high rate (typically >100Hz) asynchronously from y
 | Platform | Mechanism | Status |
 |----------|-----------|--------|
 | **ESP32-S3** | GDMA EOF (End of Frame) Interrupt | ✅ Supported |
-| **ESP32-P4** | PARLIO Buffer Switch / Transmit Done | ✅ Supported |
-| **ESP32-C6** | PARLIO Buffer Switch / Transmit Done | ✅ Supported |
+| **ESP32-P4** | PARLIO TX done (chunked queue, frame boundary) | ✅ Supported |
+| **ESP32-C6** | PARLIO TX done (chunked queue, frame boundary) | ✅ Supported |
 | **ESP32/S2** | I2S EOF Interrupt | ❌ Not yet implemented |
 
 ## Usage
@@ -147,6 +147,6 @@ void set_frame_callback(Hub75FrameCallback callback, void *arg);
 ## Implementation Details
 
 *   **ESP32-S3 (GDMA)**: Hooks into the `on_trans_eof` event of the GDMA engine. Triggers when the last descriptor in the chain (frame end) is processed.
-*   **ESP32-P4/C6 (PARLIO)**: Hooks into the `on_buffer_switched` (P4) or transaction completion events.
+*   **ESP32-P4/C6 (PARLIO)**: Hooks into the PARLIO `on_trans_done` ISR. The driver queues a frame as multiple TX chunks and counts completed chunks; the callback fires when the final chunk of a frame completes.
 
 The driver handles the low-level ISR registration logic internally, ensuring the callback is attached to the correct hardware channel/unit.


### PR DESCRIPTION
Hello!
would be nice to have this feature!

# Frame Synchronization

The ESP-HUB75 driver supports hardware-based frame synchronization to eliminate visual artifacts like tearing and jitter during fast animations.

By registering a callback, your application can be notified exactly when the hardware has finished transmitting a full frame to the display. This allows you to synchronize your rendering loop with the refresh rate of the panel (similar to VSYNC).

## Why is this needed?

The LED matrix refreshes at a high rate (typically >100Hz) asynchronously from your application code.
- **Without synchronization**: If you update the display buffer while the hardware is in the middle of sending a frame, "tearing" occurs (part of the old frame and part of the new frame are shown simultaneously).
- **With synchronization**: You wait for a frame to complete, then update the buffer content during the blanking interval or swap buffers immediately before the next frame starts.

## Supported Platforms

| Platform | Mechanism | Status |
|----------|-----------|--------|
| **ESP32-S3** | GDMA EOF (End of Frame) Interrupt | ✅ Supported |
| **ESP32-P4** | PARLIO Buffer Switch / Transmit Done | ✅ Supported |
| **ESP32-C6** | PARLIO Buffer Switch / Transmit Done | ✅ Supported |
| **ESP32/S2** | I2S EOF Interrupt | ❌ Not yet implemented |

## Usage

### 1. Define the Callback

The callback is executed in **ISR (Interrupt Service Routine) context**. Keep the code minimal. Do not use blocking operations, `printf`, or heavy logic.

The recommended pattern is to signal a notification or semaphore to wake up your main task.

```cpp
#include "hub75.h"
#include <freertos/FreeRTOS.h>
#include <freertos/semphr.h>

// Semaphore to signal main task
SemaphoreHandle_t frame_sync_sem = NULL;

// Callback function (returns true to request context switch)
bool IRAM_ATTR my_frame_callback(void *arg) {
    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
    if (frame_sync_sem) {
        xSemaphoreGiveFromISR(frame_sync_sem, &xHigherPriorityTaskWoken);
    }
    return xHigherPriorityTaskWoken == pdTRUE;
}
```

### 2. Register the Callback

Register the callback after initializing the driver.

**Using `Hub75Driver` directly:**

```cpp
Hub75Driver driver(config);
driver.begin();

// Register callback
driver.set_frame_callback(my_frame_callback, NULL);
```


### 3. Synchronize Your Loop

In your animation task, wait for the semaphore before drawing or swapping buffers.

```cpp
void animation_task(void *pvParam) {
    frame_sync_sem = xSemaphoreCreateBinary();
    
    // Register callback (as shown above)
    // ...

    for (;;) {
        // 1. Prepare next frame content (draw to back buffer)
        draw_animation();

        // 2. Wait for hardware VSYNC
        // Wait for the semaphore signaled by the ISR
        if (xSemaphoreTake(frame_sync_sem, pdMS_TO_TICKS(50)) == pdTRUE) {
            // 3. Swap buffers immediately after frame boundary
             matrix.flipDMABuffer();
        } else {
             // Timeout (hardware not running?)
        }
    }
}
```

## Timing Considerations

The timing between the "End of Frame" signal and the start of the next frame is extremely tight (often just a few microseconds).

**Incorrect Approach:**
Waiting for the sync signal and *then* drawing pixels will result in a frame rate drop, as the display hardware will idle or repeat the previous frame while you draw.

**Correct Approach:**
1.  **Draw first**: Render your animation to the back buffer totally asynchronously.
2.  **Wait**: Block on the semaphore until the hardware says "Frame Done".
3.  **Flip immediately**: Perform the buffer swap (`flipDMABuffer()`) instantly.

This ensures that the new buffer is ready exactly when the hardware is ready to accept it, ensuring 0-latency updates and maximum brightness.

## Understanding Refresh Rate

The physical refresh rate of the panel is constant and determined by the hardware configuration, not your drawing speed. It is influenced by:

1.  **Clock Speed**: The speed at which data is shifted into the panels (default 20MHz). Higher is faster.
2.  **Color Depth**: The number of bits per color channel (e.g., 8-bit vs 12-bit).
    *   The driver uses Binary Code Modulation (BCM). To display 8 bits of color, it must refresh the screen 8 times (with varying durations) for a single "perceived" frame.
    *   **Lowering bit depth** dramatically increases refresh rate.
3.  **Resolution & Scan Mode**:
    *   Total number of pixels in the chain.
    *   1/32 scan panels require more shifting per frame than 1/16 scan panels.

**Approximate Relationship:**
$$ FPS \propto \frac{ClockFrequency}{Width \times Height \times ColorDepth} $$

If you encounter flickering or low refresh rates, try:
*   Increasing the clock speed (if the cable/panel supports it).
*   Reducing the color depth (e.g., from default to lower precision if acceptable).

## API Reference

### `Hub75FrameCallback`

Type definition for the callback function pointer.

```cpp
typedef bool (*Hub75FrameCallback)(void *arg);
```

*   **Returns**: `bool`. Return `true` if a high-priority task was woken (requires context switch), `false` otherwise.
*   **Arg**: User argument pointer passed during registration.

### `set_frame_callback`

Registers or unregisters the callback.

```cpp
void set_frame_callback(Hub75FrameCallback callback, void *arg);
```

*   **callback**: The function to call. Pass `NULL` to disable/unregister.
*   **arg**: Optional argument passed to the callback.

## Implementation Details

*   **ESP32-S3 (GDMA)**: Hooks into the `on_trans_eof` event of the GDMA engine. Triggers when the last descriptor in the chain (frame end) is processed.
*   **ESP32-P4/C6 (PARLIO)**: Hooks into the `on_buffer_switched` (P4) or transaction completion events.

The driver handles the low-level ISR registration logic internally, ensuring the callback is attached to the correct hardware channel/unit.
