### PR TITLE
Fix BCM timing calculation to use actual I2S clock speed

### DIFF
--- a/components/hub75/src/platforms/i2s/i2s_dma.h
+++ b/components/hub75/src/platforms/i2s/i2s_dma.h
@@ -124,6 +124,7 @@ class I2sDma : public PlatformDma {
   volatile i2s_dev_t *i2s_dev_;
   const uint8_t bit_depth_;      // Bit depth from config (6, 7, 8, 10, or 12)
   uint8_t lsbMsbTransitionBit_;  // BCM optimization threshold (calculated at init)
+  uint32_t actual_clock_hz_;     // Actual I2S clock frequency (may differ from config due to fallbacks)
 
   // Panel configuration (immutable, cached from config)
   const uint16_t panel_width_;


### PR DESCRIPTION
The calculate_bcm_timings() function was using config_.output_clock_speed
to calculate buffer transmission time, but configure_i2s_timing() may
fall back to a different clock speed when the requested speed isn't
achievable on the target platform (e.g., 32MHz requested on ESP32-S2
falls back to 20MHz).

This fix adds an actual_clock_hz_ member variable that stores the
resolved clock frequency from configure_i2s_timing(), and updates
calculate_bcm_timings() to use this actual value instead of the
configured value. This ensures accurate refresh rate calculations.