### PR TITLE
fix(drivers): wire FM6124 to the FM6126A init sequence

### DIFF
--- a/components/hub75/src/drivers/fm6126a.cpp
+++ b/components/hub75/src/drivers/fm6126a.cpp
@@ -95,6 +95,8 @@ esp_err_t DriverInit::initialize(const Hub75Config &config) {
 
     case Hub75ShiftDriver::FM6126A:
     case Hub75ShiftDriver::ICN2038S:
+    case Hub75ShiftDriver::FM6124:
+      // FM6124 uses the same REG1/REG2 init sequence as FM6126A.
       fm6126a_init(config.pins, pixels_per_row);
       return ESP_OK;
 
@@ -105,10 +107,6 @@ esp_err_t DriverInit::initialize(const Hub75Config &config) {
     case Hub75ShiftDriver::MBI5124:
       ESP_LOGW(TAG, "MBI5124: Ensure clk_phase_inverted is set to true");
       return ESP_OK;
-
-    case Hub75ShiftDriver::FM6124:
-      ESP_LOGW(TAG, "FM6124 initialization not yet implemented");
-      return ESP_ERR_NOT_SUPPORTED;
 
     default:
       ESP_LOGW(TAG, "Unknown shift driver: %d", (int) config.shift_driver);


### PR DESCRIPTION
## Summary
- `Hub75ShiftDriver::FM6124` previously hit a dedicated case that logged a warning and returned `ESP_ERR_NOT_SUPPORTED`, so `Hub75Driver::begin()` failed outright when users selected FM6124 in Kconfig or in code.
- FM6124 panels respond to the same REG1 (brightness) and REG2 (output enable) initialization that `fm6126a_init()` already performs for FM6126A/ICN2038S, so this PR routes FM6124 to that function and drops the `ESP_ERR_NOT_SUPPORTED` case.

Reported in #126 with an FM6124EJ 32×32 panel; with this change the `FM6124` selection is functional rather than a guaranteed init failure.

## Test plan
- [ ] Build `simple_colors` example with `CONFIG_HUB75_DRIVER_FM6124=y` for ESP32-S3 / ESP32-P4 (CI compile coverage).
- [ ] On hardware (FM6124 / FM6124EJ panel), verify panel lights up and shows the test pattern with `shift_driver = Hub75ShiftDriver::FM6124`.
- [ ] Confirm FM6126A and ICN2038S behavior is unchanged (same code path, no functional change for those drivers).