### PR TITLE
feat(drivers): add DP3246 shift driver initialization

### DIFF
--- a/components/hub75/CMakeLists.txt
+++ b/components/hub75/CMakeLists.txt
@@ -35,6 +35,7 @@ idf_component_register(
         "src/platforms/platform_detect.cpp"
         "src/platforms/platform_dma.cpp"
         "src/drivers/fm6126a.cpp"
+        "src/drivers/dp3246.cpp"
         # Platform-specific sources added conditionally below
     INCLUDE_DIRS
         "include"

--- a/components/hub75/Kconfig
+++ b/components/hub75/Kconfig
@@ -211,6 +211,13 @@ menu "HUB75 RGB LED Matrix Driver"
 
             config HUB75_DRIVER_DP3246
                 bool "DP3246"
+                help
+                    DP3246 driver chips with SM5368 row addressing.
+                    Auto-enables CLK_PHASE_INVERTED (rising-edge clock).
+
+                    Note: runtime 3-cycle LAT widening is not yet implemented;
+                    only the bit-bang init sequence runs. Panels may show
+                    artifacts until the DMA-side LAT widening is added.
         endchoice
 
         choice HUB75_BIT_DEPTH_CHOICE
@@ -705,12 +712,14 @@ menu "HUB75 RGB LED Matrix Driver"
         config HUB75_CLK_PHASE_INVERTED
             bool "Invert clock phase"
             default y if HUB75_DRIVER_MBI5124
+            default y if HUB75_DRIVER_DP3246
             default n
             help
                 Inverts the clock signal phase.
 
-                Required for MBI5124 driver chips (auto-enabled when MBI5124
-                is selected). Most other driver chips do not need this.
+                Required for MBI5124 and DP3246 driver chips (auto-enabled
+                when either is selected). Most other driver chips do not
+                need this.
 
                 Leave disabled unless your panel specifically requires it.
 

--- a/components/hub75/Kconfig
+++ b/components/hub75/Kconfig
@@ -212,7 +212,8 @@ menu "HUB75 RGB LED Matrix Driver"
             config HUB75_DRIVER_DP3246
                 bool "DP3246"
                 help
-                    DP3246 driver chips with SM5368 row addressing.
+                    Initializes DP3246 column driver chips. Row addressing
+                    must be configured separately to match the panel.
                     Auto-enables CLK_PHASE_INVERTED (rising-edge clock).
 
                     Note: runtime 3-cycle LAT widening is not yet implemented;

--- a/components/hub75/src/drivers/dp3246.cpp
+++ b/components/hub75/src/drivers/dp3246.cpp
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2025 Stuart Parmenter
+// SPDX-License-Identifier: MIT
+
+// @file dp3246.cpp
+// @brief DP3246 shift driver initialization
+
+#include "driver_init.h"
+#include "driver/gpio.h"
+#include "esp_log.h"
+#include <initializer_list>
+
+namespace hub75 {
+
+static const char *const TAG = "DP3246";
+
+#define CLK_PULSE \
+  gpio_set_level((gpio_num_t) pins.clk, 1); \
+  gpio_set_level((gpio_num_t) pins.clk, 0);
+
+// LAT cycle counts at the tail of each shift. The 3-cycle blank shape is
+// DP3246-specific (FM6126A uses a 1-cycle latch for blanks); REG1/REG2 widths
+// match the FM6126A-family register-commit convention.
+static constexpr uint16_t LAT_CYCLES_BLANK = 3;
+static constexpr uint16_t LAT_CYCLES_REG1 = 11;
+static constexpr uint16_t LAT_CYCLES_REG2 = 12;
+
+// Shift `pixels_per_row` clocks across the panel, raising LAT for the final
+// `lat_cycles` clocks and dropping it after the loop. If `pattern` is non-null,
+// each clock writes pattern[i%16] to the six RGB data lines (MSB-first 16-bit
+// shift). If null, RGB lines are left untouched (caller controls their state).
+static void shift_with_latch(const Hub75Pins &pins, uint16_t pixels_per_row, const bool *pattern, uint16_t lat_cycles) {
+  const uint16_t lat_start = pixels_per_row - lat_cycles;
+  for (uint16_t i = 0; i < pixels_per_row; i++) {
+    if (pattern != nullptr) {
+      const bool bit = pattern[i % 16];
+      for (uint8_t pin : {pins.r1, pins.r2, pins.g1, pins.g2, pins.b1, pins.b2}) {
+        gpio_set_level((gpio_num_t) pin, bit);
+      }
+    }
+    if (i >= lat_start) {
+      gpio_set_level((gpio_num_t) pins.lat, 1);
+    }
+    CLK_PULSE;
+  }
+  gpio_set_level((gpio_num_t) pins.lat, 0);
+}
+
+void DriverInit::dp3246_init(const Hub75Pins &pins, uint16_t pixels_per_row) {
+  ESP_LOGI(TAG, "Initializing DP3246 shift driver (pixels_per_row=%d)", pixels_per_row);
+
+  // DP3246 also needs LAT held high for 3 clock cycles per row at runtime.
+  // The DMA streams currently emit a 1-cycle LAT pulse; runtime LAT widening
+  // is not yet implemented, so the panel may show artifacts even after this
+  // init succeeds. Init still runs so REG1/REG2 get programmed.
+  ESP_LOGW(TAG, "DP3246: runtime 3-cycle LAT widening not yet implemented");
+
+  // REG1 (MSB-first, 16 bits, written into the cascaded 16-bit shift registers)
+  //   15:13   000        reserved
+  //   12:9    0000       OE widening (= OE_ADD * 6 ns)
+  //   8       0          reserved
+  //   7:0     11111111   Iout = (Igain + 1) / 256 * 17.6 / Rext  (max gain)
+  static constexpr bool REG1[16] = {false, false, false, false, false, false, false, false,
+                                    true,  true,  true,  true,  true,  true,  true,  true};
+
+  // REG2 (MSB-first, 16 bits)
+  //   15:11   11111      Blanking potential select (00000 = VDD-0.8 V, step 77 mV)
+  //   10:8    111        Constant-current source inflection point
+  //   7       0          Disable dead-pixel removal (1 = enable)
+  //   6       0          OPEN_DET reset (rising edge starts detection)
+  //   5       0          Enable black-screen power saving (1 = disable)
+  //   4       0          Disable fade
+  //   3       0          Reserved
+  //   2:0     000        Single-edge data transfer
+  static constexpr bool REG2[16] = {true,  true,  true,  true,  true,  true,  true,  true,
+                                    false, false, false, false, false, false, false, false};
+
+  // 1. Configure all pins as GPIO output
+  for (uint8_t pin : {pins.r1, pins.r2, pins.g1, pins.g2, pins.b1, pins.b2, pins.clk, pins.lat, pins.oe}) {
+    gpio_reset_pin((gpio_num_t) pin);
+    gpio_set_direction((gpio_num_t) pin, GPIO_MODE_OUTPUT);
+    gpio_set_level((gpio_num_t) pin, 0);
+  }
+
+  // 2. Disable display (OE high)
+  gpio_set_level((gpio_num_t) pins.oe, 1);
+
+  // 3. Pre-clear sweep (3-cycle LAT, no RGB writes — lines are already low from step 1)
+  shift_with_latch(pins, pixels_per_row, nullptr, LAT_CYCLES_BLANK);
+
+  // 4. Send REG1 (LAT high for the last 11 clocks to commit the register)
+  shift_with_latch(pins, pixels_per_row, REG1, LAT_CYCLES_REG1);
+
+  // 5. Send REG2 (LAT high for the last 12 clocks to commit the register)
+  shift_with_latch(pins, pixels_per_row, REG2, LAT_CYCLES_REG2);
+  CLK_PULSE;  // DP3246 expects an extra clock after dropping LAT post-REG2
+
+  // 6. Drive RGB lines low so the trailing blank sweep doesn't leave stale data
+  for (uint8_t pin : {pins.r1, pins.r2, pins.g1, pins.g2, pins.b1, pins.b2}) {
+    gpio_set_level((gpio_num_t) pin, 0);
+  }
+
+  // 7. Trailing blank sweep (matches the 3-cycle LAT shape of step 3)
+  shift_with_latch(pins, pixels_per_row, nullptr, LAT_CYCLES_BLANK);
+
+  // 8. Enable display
+  gpio_set_level((gpio_num_t) pins.oe, 0);
+  CLK_PULSE;
+
+  ESP_LOGI(TAG, "DP3246 initialized successfully");
+}
+
+}  // namespace hub75

--- a/components/hub75/src/drivers/fm6126a.cpp
+++ b/components/hub75/src/drivers/fm6126a.cpp
@@ -80,11 +80,6 @@ void DriverInit::fm6126a_init(const Hub75Pins &pins, uint16_t pixels_per_row) {
   ESP_LOGI(TAG, "FM6126A initialized successfully");
 }
 
-void DriverInit::dp3246_init(const Hub75Pins &pins, uint16_t pixels_per_row) {
-  // TODO: Port from reference library when hardware available
-  ESP_LOGW(TAG, "DP3246 initialization not yet implemented");
-}
-
 esp_err_t DriverInit::initialize(const Hub75Config &config) {
   uint16_t pixels_per_row = config.panel_width * config.layout_cols;
 
@@ -99,6 +94,9 @@ esp_err_t DriverInit::initialize(const Hub75Config &config) {
       return ESP_OK;
 
     case Hub75ShiftDriver::DP3246:
+      if (!config.clk_phase_inverted) {
+        ESP_LOGW(TAG, "DP3246: clk_phase_inverted should be true (rising-edge clock)");
+      }
       dp3246_init(config.pins, pixels_per_row);
       return ESP_OK;
 

--- a/components/hub75/src/drivers/fm6126a.cpp
+++ b/components/hub75/src/drivers/fm6126a.cpp
@@ -7,6 +7,7 @@
 // Based on https://github.com/mrcodetastic/ESP32-HUB75-MatrixPanel-DMA
 
 #include "driver_init.h"
+#include "../panels/scan_patterns.h"
 #include "driver/gpio.h"
 #include "esp_log.h"
 #include <initializer_list>
@@ -97,7 +98,9 @@ esp_err_t DriverInit::initialize(const Hub75Config &config) {
       if (!config.clk_phase_inverted) {
         ESP_LOGW(TAG, "DP3246: clk_phase_inverted should be true (rising-edge clock)");
       }
-      dp3246_init(config.pins, pixels_per_row);
+      // Program the entire physical shift chain, including vertical panels and four-scan expansion.
+      dp3246_init(config.pins, get_effective_dma_width(config.scan_wiring, config.panel_width, config.layout_rows,
+                                                       config.layout_cols));
       return ESP_OK;
 
     case Hub75ShiftDriver::MBI5124:


### PR DESCRIPTION
## Summary
- Replaces the `DP3246` stub (which logged `"DP3246 initialization not yet implemented"` and did nothing) with the actual bit-bang init sequence: pre-clear sweep → REG1 (max output current, no OE widening) → REG2 (max blanking potential, single-edge transfer, black-screen power saving enabled, fade and dead-pixel removal disabled) → trailing blank → OE enable. New file: `components/hub75/src/drivers/dp3246.cpp`.
- DP3246 needs rising-edge clock. `HUB75_CLK_PHASE_INVERTED` now also `default y if HUB75_DRIVER_DP3246` (mirrors the MBI5124 default). For users who construct `Hub75Config` directly in code, the dispatch in `DriverInit::initialize` logs a warning when `clk_phase_inverted` is left false.
- Internal helper `shift_with_latch(pins, pixels_per_row, pattern, lat_cycles)` collapses the four near-identical "shift N pixels, raise LAT for the last K, drop LAT" sweeps in `dp3246_init` into a single parameterized call. Latch widths are named (`LAT_CYCLES_BLANK = 3`, `LAT_CYCLES_REG1 = 11`, `LAT_CYCLES_REG2 = 12`).

- Initialization uses the same effective shift-chain width as DMA, including vertical panel chains and four-scan expansion. Kconfig documents column-driver initialization separately from row addressing.

## Known limitation (called out in code, log, and Kconfig help)
DP3246 also expects LAT held high for **3 clock cycles per row at runtime**, not just during init. The DMA backends (`gdma_dma`, `i2s_dma`, `parlio_dma`) currently emit a 1-cycle LAT pulse on the last word of each row, so panels may still show artifacts after this init succeeds. Widening the runtime LAT pulse is intentionally left to a follow-up PR — that change touches all three DMA backends and adds a new `Hub75Config::latch_pulse_width` field, which is too much for an init-only port.

## Test plan
- [x] Host GPIO recording checks against the reference at seven shift lengths (16–1024 bits): register values, LAT widths, extra clocks, and OE blanking match. Compiled and ran with C++17 and C++20.
- [x] Shift-register simulation confirms every chip is programmed for standard and 1/8-scan panels, including vertically chained panels.
- [x] Kconfig clock defaults verified for GENERIC, FM6126A, FM6124, MBI5124, and DP3246 on all five targets.
- [ ] Compile-only: build `simple_colors` example with `CONFIG_HUB75_DRIVER_DP3246=y` for ESP32, ESP32-S2, ESP32-S3, ESP32-P4, ESP32-C6 — confirm no missing symbol / link errors and that `HUB75_CLK_PHASE_INVERTED` flips on automatically.
- [ ] Confirm FM6126A / FM6124 / GENERIC paths are unchanged (DP3246 is a separate `case` branch; only addition is the conditional `clk_phase_inverted` warning).
- [ ] On hardware (DP3246 panel, when available): verify the init sequence runs without watchdog trip and that the warning about runtime LAT widening fires once at startup. End-to-end correct rendering will require the follow-up DMA-side LAT widening.
