### PR TITLE
ci: test ESP-IDF 6.1 and refresh 5.5 coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
       fail-fast: false
       matrix:
         idf_target: [esp32, esp32s2, esp32s3, esp32c6, esp32p4]
-        idf_ver: [v4.4.8, v5.5.2, v6.0]
+        idf_ver: [v4.4.8, v5.5.5, v6.1]
         # v4.4.8: Latest 4.4 bugfix release (legacy support)
-        # v5.5.2: Current stable release
-        # v6.0: Latest major release
+        # v5.5.5: Latest 5.5 bugfix release
+        # v6.1: Latest stable 6.x release
         exclude:
           # ESP32-C6 only supported on ESP-IDF 5.x+
           - idf_target: esp32c6

--- a/.github/workflows/clang-check.yml
+++ b/.github/workflows/clang-check.yml
@@ -47,6 +47,11 @@ jobs:
         run: |
           # Re-source export.sh to pick up newly installed esp-clang
           . $IDF_PATH/export.sh
+          if [ "${{ matrix.idf_target }}" = "esp32p4" ]; then
+            # ESP-IDF 5.5.5's Clang toolchain does not support P4 revision 3.x.
+            # Keep this override local to analysis; GCC builds use the IDF defaults.
+            echo "CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y" >> sdkconfig.defaults
+          fi
           idf.py set-target ${{ matrix.idf_target }}
           idf.py clang-check --run-clang-tidy-py run-clang-tidy --run-clang-tidy-options ""
 

--- a/.github/workflows/clang-check.yml
+++ b/.github/workflows/clang-check.yml
@@ -20,7 +20,7 @@ jobs:
         idf_target: [esp32, esp32s2, esp32s3, esp32c6, esp32p4]
 
     container:
-      image: espressif/idf:v5.5.2
+      image: espressif/idf:v5.5.5
 
     env:
       IDF_TOOLCHAIN: clang

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
             build-mode: manual
 
     container:
-      image: ${{ matrix.language == 'c-cpp' && 'espressif/idf:v5.5.2' || '' }}
+      image: ${{ matrix.language == 'c-cpp' && 'espressif/idf:v5.5.5' || '' }}
 
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 High-performance DMA-based driver for HUB75 RGB LED matrix panels, supporting ESP32, ESP32-S2, ESP32-S3, ESP32-C6, and ESP32-P4.
 
-**Requires ESP-IDF 4.4.8+** (ESP32-C6/P4 require 5.1+). Tested with 4.4.8, 5.5.2, and 6.0.
+**Requires ESP-IDF 4.4.8+** (ESP32-C6/P4 require 5.1+). Tested with 4.4.8, 5.5.5, and 6.1.
 
 ## Features
 

--- a/components/hub75/src/platforms/gdma/gdma_dma.cpp
+++ b/components/hub75/src/platforms/gdma/gdma_dma.cpp
@@ -141,7 +141,8 @@ bool GdmaDma::init() {
   // Allocate GDMA channel
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
   // ESP-IDF 6.0+: simplified config, direction via NULL parameter
-  gdma_channel_alloc_config_t dma_alloc_config = {.flags = {.isr_cache_safe = 0}};
+  // Zero-initialize all fields, including intr_priority added in ESP-IDF 6.1.
+  gdma_channel_alloc_config_t dma_alloc_config = {};
   esp_err_t err = gdma_new_ahb_channel(&dma_alloc_config, &dma_chan_, nullptr);
 
 #elif ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)


### PR DESCRIPTION
Update CI to test ESP-IDF [6.1](https://github.com/espressif/esp-idf/releases/tag/v6.1) and [5.5.5](https://github.com/espressif/esp-idf/releases/tag/v5.5.5), retaining 4.4.8 legacy coverage. Update the Clang-Tidy and CodeQL containers to 5.5.5 and align the README with the build matrix.

The newer versions require two compatibility adjustments:
- Zero-initialize the ESP-IDF 6.x GDMA allocation configuration so the new 6.1 `intr_priority` field receives its default value without a missing-field-initializer error. This also preserves compatibility with 6.0.
- Select ESP32-P4 revisions below 3.0 for the Clang-Tidy job because the 5.5.5 Clang toolchain rejects the new default revision family. The override is confined to analysis; GCC builds use the SDK defaults.

The observed main-branch failure was a Docker Hub connection reset while pulling 6.0, rather than a missing image tag. This change refreshes version coverage; it does not address transient registry failures.

Validation: confirmed Docker image availability, parsed the workflow YAML, verified the P4 override against ESP-IDF 5.5.5's Kconfig, and passed `git diff --check`. The updated build and analysis matrix is running on this PR.
