### PR TITLE
fix(i2s): correct ESP32 clock source and 20 MHz accounting

### DIFF
--- a/components/hub75/Kconfig
+++ b/components/hub75/Kconfig
@@ -356,8 +356,7 @@ menu "HUB75 RGB LED Matrix Driver"
                 issues on long cables or with some panels.
 
                 Platform limits (falls back with warning if exceeded):
-                  - ESP32: 10 MHz max
-                  - ESP32-S2: 20 MHz max
+                  - ESP32/ESP32-S2: 20 MHz max
                   - ESP32-S3/P4/C6: 32 MHz
 
             config HUB75_CLK_8MHZ

--- a/components/hub75/src/platforms/i2s/i2s_dma.cpp
+++ b/components/hub75/src/platforms/i2s/i2s_dma.cpp
@@ -291,47 +291,21 @@ bool I2sDma::init() {
 }
 
 HUB75_CONST uint32_t I2sDma::resolve_actual_clock_speed(Hub75ClockSpeed clock_speed) const {
-  // I2S LCD mode clock derivation:
-  //   Output = base_clock / clkm_div / (tx_bck_div_num * 2)
-  //   We use tx_bck_div_num = 2, so: Output = base_clock / clkm_div / 4
+  // Both ESP32 and ESP32-S2 use a 160 MHz PLL source. On ESP32 this is
+  // selected by clka_en = 0 (PLL_F160M_CLK, historically called PLL_D2_CLK).
+  // LCD mode outputs WS at half BCK, and we use tx_bck_div_num = 2:
+  //   Output = 160 MHz / clkm_div / (2 * 2)
   //
-  // TRM Constraints (ESP32 TRM v5.3, Section 12.6):
-  //   - clkm_div >= 2: "I2S_CLKM_DIV_NUM: Integral I2S clock divider value.
-  //     fI2S = fCLK / I2S_CLKM_DIV_NUM (I2S_CLKM_DIV_NUM >= 2)"
-  //   - tx_bck_div_num >= 2: Required for LCD mode stability
-  //
-  // These constraints limit max achievable frequency significantly compared
-  // to ESP32-S3's LCD_CAM peripheral which has no such divider requirements.
+  // ESP32 TRM v5.8, Sections 22.3 and 22.5: both dividers must be >= 2.
+  // Max output: 160 / 2 / 4 = 20 MHz. Keep integer dividers to avoid jitter.
+  // Available: 20 MHz (div=2), 13.33 MHz (div=3), 10 MHz (div=4), 8 MHz (div=5).
   uint32_t requested_hz = static_cast<uint32_t>(clock_speed);
-
-#if defined(CONFIG_IDF_TARGET_ESP32S2)
-  // ESP32-S2: PLL_160M clock source (160 MHz base)
-  // Max output: 160 / 2 / 4 = 20 MHz (with minimum dividers)
-  // Available: 20 MHz (div=2), 13.33 MHz (div=3), 10 MHz (div=4), 8 MHz (div=5), ...
-  //
-  // Note: Higher speeds would require clkm_div < 2, which violates TRM constraints
-  // and causes unreliable operation.
   if (requested_hz > 20000000) {
-    ESP_LOGW(TAG, "Requested %u Hz exceeds ESP32-S2 max (20 MHz), using 20 MHz", (unsigned int) requested_hz);
+    ESP_LOGW(TAG, "Requested %u Hz exceeds I2S LCD max (20 MHz), using 20 MHz", (unsigned int) requested_hz);
     return 20000000;
   }
   uint32_t divider = (160000000 + requested_hz * 2) / (requested_hz * 4);  // Round to nearest
   return 160000000 / (std::max(divider, uint32_t{2}) * 4);
-
-#else
-  // ESP32: PLL_D2_CLK clock source (80 MHz base)
-  // Max output: 80 / 2 / 4 = 10 MHz (with minimum dividers)
-  // Available: 10 MHz (div=2), 6.67 MHz (div=3), 5 MHz (div=4), 4 MHz (div=5), ...
-  //
-  // The ESP32's lower base clock (80 MHz vs 160 MHz) combined with the same
-  // divider constraints results in half the max frequency of ESP32-S2.
-  if (requested_hz > 10000000) {
-    ESP_LOGW(TAG, "Requested %u Hz exceeds ESP32 max (10 MHz), using 10 MHz", (unsigned int) requested_hz);
-    return 10000000;
-  }
-  uint32_t divider = (80000000 + requested_hz * 2) / (requested_hz * 4);  // Round to nearest
-  return 80000000 / (std::max(divider, uint32_t{2}) * 4);
-#endif
 }
 
 void I2sDma::configure_i2s_timing() {
@@ -363,7 +337,7 @@ void I2sDma::configure_i2s_timing() {
   dev->clkm_conf.clkm_div_num = clkm_div;
   dev->clkm_conf.clk_en = 1;
 
-  // BCK divider (must be >= 2 per TRM Section 12.6)
+  // BCK divider (must be >= 2)
   dev->sample_rate_conf.rx_bck_div_num = 2;
   dev->sample_rate_conf.tx_bck_div_num = 2;
 
@@ -371,24 +345,24 @@ void I2sDma::configure_i2s_timing() {
            actual_clock_hz_ / 1000000.0f, (unsigned int) (requested_hz / 1000000));
 
 #else
-  // ESP32: PLL_D2_CLK clock source (80MHz)
-  // Output Frequency = 80MHz / clkm_div_num / (tx_bck_div_num * 2)
-  // Reference: ESP32 TRM v5.3, Section 12.5 (I2S Clock)
-  // Constraints: clkm_div_num >= 2, tx_bck_div_num >= 2 (TRM Section 12.6)
-  dev->clkm_conf.clka_en = 0;  // PLL_D2_CLK (80MHz)
+  // ESP32: PLL_F160M_CLK clock source (historically called PLL_D2_CLK)
+  // Output Frequency = 160MHz / clkm_div_num / (tx_bck_div_num * 2)
+  // Reference: ESP32 TRM v5.8, Sections 22.3 (I2S Clock) and 22.5 (LCD mode)
+  // Constraints: clkm_div_num >= 2, tx_bck_div_num >= 2
+  dev->clkm_conf.clka_en = 0;  // PLL_F160M_CLK (160MHz), APLL disabled
   dev->clkm_conf.clkm_div_a = 1;
   dev->clkm_conf.clkm_div_b = 0;
 
-  // Calculate divider from actual frequency: actual = 80M / (div * 4)
-  unsigned int clkm_div = 80000000 / (actual_clock_hz_ * 4);
+  // Calculate divider from actual frequency: actual = 160M / (div * 4)
+  unsigned int clkm_div = 160000000 / (actual_clock_hz_ * 4);
 
   dev->clkm_conf.clkm_div_num = clkm_div;
 
-  // BCK divider (must be >= 2 per TRM Section 12.6)
+  // BCK divider (must be >= 2)
   dev->sample_rate_conf.tx_bck_div_num = 2;
   dev->sample_rate_conf.rx_bck_div_num = 2;
 
-  ESP_LOGI(TAG, "ESP32 I2S clock: 80MHz / %u / 4 = %.2f MHz (requested %u MHz)", clkm_div,
+  ESP_LOGI(TAG, "ESP32 I2S clock: 160MHz / %u / 4 = %.2f MHz (requested %u MHz)", clkm_div,
            actual_clock_hz_ / 1000000.0f, (unsigned int) (requested_hz / 1000000));
 #endif
 }

--- a/docs/PLATFORMS.md
+++ b/docs/PLATFORMS.md
@@ -12,7 +12,7 @@ Detailed comparison and implementation notes for ESP32 platform variants.
 | **Buffer Size** (64×64) | ~57 KB | ~57 KB | ~57 KB | ~284 KB | ~284 KB |
 | **BCM Method** | Descriptor dup | Descriptor dup | Descriptor dup | Buffer padding | Buffer padding |
 | **Clock Gating** | No | No | No | **Yes** (MSB) | **No** |
-| **Max Clock** | 10 MHz | 20 MHz | 40 MHz | 40 MHz+ | 40 MHz+ |
+| **Max Clock** | 20 MHz | 20 MHz | 40 MHz | 40 MHz+ | 40 MHz+ |
 | **Status** | ✅ Tested | ✅ Tested | ✅ Tested | ✅ Tested | ⏳ Planned |
 
 ---
@@ -31,51 +31,45 @@ Clock speeds are automatically resolved to the nearest achievable frequency:
 
 | Requested | ESP32 | ESP32-S2 | ESP32-S3/P4/C6 | Actual (S3/P4/C6) |
 |-----------|-------|----------|----------------|-------------------|
-| **32 MHz** | ⚠️ 10 MHz | ⚠️ 20 MHz | ✅ 32 MHz | 32.00 MHz (160/5) |
-| **27 MHz** | ⚠️ 10 MHz | ⚠️ 20 MHz | ✅ 26.67 MHz | 26.67 MHz (160/6) |
-| **23 MHz** | ⚠️ 10 MHz | ⚠️ 20 MHz | ✅ 22.86 MHz | 22.86 MHz (160/7) |
-| **20 MHz** | ⚠️ 10 MHz | ✅ 20 MHz | ✅ 20 MHz | 20.00 MHz (160/8) |
-| **18 MHz** | ⚠️ 10 MHz | ⚠️ 10 MHz | ✅ 17.78 MHz | 17.78 MHz (160/9) |
-| **16 MHz** | ⚠️ 10 MHz | ⚠️ 10 MHz | ✅ 16 MHz | 16.00 MHz (160/10) |
+| **32 MHz** | ⚠️ 20 MHz | ⚠️ 20 MHz | ✅ 32 MHz | 32.00 MHz (160/5) |
+| **27 MHz** | ⚠️ 20 MHz | ⚠️ 20 MHz | ✅ 26.67 MHz | 26.67 MHz (160/6) |
+| **23 MHz** | ⚠️ 20 MHz | ⚠️ 20 MHz | ✅ 22.86 MHz | 22.86 MHz (160/7) |
+| **20 MHz** | ✅ 20 MHz | ✅ 20 MHz | ✅ 20 MHz | 20.00 MHz (160/8) |
+| **18 MHz** | ⚠️ 20 MHz | ⚠️ 20 MHz | ✅ 17.78 MHz | 17.78 MHz (160/9) |
+| **16 MHz** | ⚠️ 13.33 MHz | ⚠️ 13.33 MHz | ✅ 16 MHz | 16.00 MHz (160/10) |
 | **10 MHz** | ✅ 10 MHz | ✅ 10 MHz | ✅ 10 MHz | 10.00 MHz (160/16) |
-| **8 MHz** | ⚠️ 5 MHz | ✅ 8 MHz | ✅ 8 MHz | 8.00 MHz (160/20) |
+| **8 MHz** | ✅ 8 MHz | ✅ 8 MHz | ✅ 8 MHz | 8.00 MHz (160/20) |
 
-⚠️ = Falls back to nearest achievable frequency (warning logged at runtime)
+⚠️ = Resolves to a different frequency (logged at runtime; requests above the platform maximum also produce a warning)
 
-### ESP32 Clock Limitations
+### ESP32 / ESP32-S2 Clock Configuration
 
-The ESP32 uses PLL_D2_CLK (80 MHz) as the I2S clock source. The output frequency is:
-
-```
-Output = 80 MHz / clkm_div_num / (tx_bck_div_num × 2)
-```
-
-Per the ESP32 TRM (Section 12.6), both `clkm_div_num` and `tx_bck_div_num` must be ≥ 2.
-With minimum dividers (2, 2), the maximum achievable frequency is:
-
-```
-80 MHz / 2 / 4 = 10 MHz (maximum)
-```
-
-Higher frequencies (16/20 MHz) would require `clkm_div_num < 2`, which violates TRM
-constraints and produces undefined behavior.
-
-### ESP32-S2 Clock Configuration
-
-The ESP32-S2 uses PLL_160M (160 MHz) as the I2S clock source:
+Both chips use a 160 MHz PLL source. On ESP32, clearing `clka_en` selects
+PLL_F160M_CLK (historically named PLL_D2_CLK); on ESP32-S2, `clk_sel = 2`
+selects PLL_160M_CLK. In LCD mode, the output WS clock is half the BCK frequency:
 
 ```
 Output = 160 MHz / clkm_div_num / (tx_bck_div_num × 2)
 ```
 
-With the same divider constraints, more frequencies are achievable:
+Both dividers must be ≥ 2. With the driver's fixed `tx_bck_div_num = 2`, the
+maximum supported output is `160 MHz / 2 / 4 = 20 MHz`. Requests above 20 MHz
+are capped; other requests round the CLKM divider to the nearest integer.
+Fractional dividers are not used, avoiding clock jitter.
 
-| Speed | clkm_div | Formula | Result |
-|-------|----------|---------|--------|
-| 20 MHz | 2 | 160/2/4 | 20 MHz ✓ |
-| 16 MHz | — | Not achievable with integer dividers | Falls back to 10 MHz |
-| 10 MHz | 4 | 160/4/4 | 10 MHz ✓ |
-| 8 MHz | 5 | 160/5/4 | 8 MHz ✓ |
+| Requested | clkm_div | Formula | Actual |
+|-----------|----------|---------|--------|
+| 20 MHz | 2 | 160/2/4 | 20 MHz |
+| 18 MHz | 2 | 160/2/4 | 20 MHz |
+| 16 MHz | 3 | 160/3/4 | 13.33 MHz |
+| 10 MHz | 4 | 160/4/4 | 10 MHz |
+| 8 MHz | 5 | 160/5/4 | 8 MHz |
+
+Earlier ESP32 code assumed an 80 MHz source, so its reported frequency and BCM
+refresh calculations were half the frequency implied by the programmed dividers.
+For example, the old 10 MHz setting programmed dividers 2 and 2, which produce
+20 MHz. The corrected 10 MHz setting uses dividers 4 and 2; a 20 MHz request
+keeps dividers 2 and 2 and accounts for that frequency correctly.
 
 ### ESP32-S3 / ESP32-P4 / ESP32-C6
 
@@ -95,7 +89,7 @@ All standard frequencies (8/10/16/20/32 MHz) divide evenly from 160 MHz.
 
 ### References
 
-- ESP32 TRM v5.3, Section 12.5-12.6 (I2S Clock)
+- [ESP32 TRM v5.8](https://www.espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf), Sections 22.3 (I2S Clock) and 22.5 (LCD mode)
 - ESP32-S2 TRM v1.5, Section 12.5-12.6 (I2S Clock)
 - ESP32-S3 TRM, Chapter 26 (LCD_CAM)
 
@@ -150,7 +144,7 @@ All standard frequencies (8/10/16/20/32 MHz) divide evenly from 160 MHz.
 ### Limitations
 
 - **I2S peripheral misuse**: Designed for audio, not parallel data
-- **Clock speed limits**: ESP32 max 10 MHz, ESP32-S2 max 20 MHz (see [Clock Speed Reference](#clock-speed-reference))
+- **Clock speed limits**: ESP32 and ESP32-S2 max 20 MHz (see [Clock Speed Reference](#clock-speed-reference))
 - **No PSRAM support**: All buffers must be internal SRAM
 
 ### Advantages


### PR DESCRIPTION
The ESP32 I2S backend assumes an 80 MHz source, but `clka_en = 0` selects the 160 MHz PLL source. Consequently, it reports half the frequency implied by its programmed dividers and uses that incorrect value for BCM refresh calculations. For example, a 20 MHz request currently programs CLKM/BCK dividers 2/2 but reports 10 MHz.

Use the same 160 MHz clock calculation as ESP32-S2, retaining the documented minimum divider of 2 and a 20 MHz maximum. A 20 MHz request keeps the existing 2/2 register configuration and now reports 20 MHz correctly; a 10 MHz request uses 4/2 to actually produce 10 MHz. Update the warning, Kconfig limit, and platform frequency tables, including the existing S2 rounding for 16 and 18 MHz. S2 register settings and resolved frequencies are unchanged.

This separates the clock issue raised by @Lukaswnd in #116 from its external-framebuffer and C6 work. The 20 MHz capability is supported, but lowering CLKM to 1 while retaining the 80 MHz assumption would violate the documented divider minimum. This PR corrects the source-frequency model instead.

References: [ESP32 TRM v5.8, sections 22.3 and 22.5](https://www.espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf), and [Espressif's ESP32 I2S HAL clock definition and selection](https://github.com/espressif/esp-idf/blob/v5.5.2/components/hal/esp32/include/hal/i2s_ll.h#L51).

Validation:

- Local ESP-IDF 6.1 builds for ESP32 and ESP32-S2.
- Host checks of the actual resolver/register-setup function bodies for all eight clock enum values, compiled and run in C++17 and C++20 for both targets. Checked output/reporting agreement, minimum dividers, integer-only clock selection, preservation of ESP32's 20 MHz register setup, and S2 compatibility against main.
- Clang-format 22.1.4 and `git diff --check` pass.
- Physical CLK/frame timing has not been measured on hardware.
